### PR TITLE
chore: prepare dquic v0.7.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,12 +102,12 @@ qevent = { path = "./qevent", version = "0.6.0" }
 qudp = { path = "./qudp", version = "0.6.0" }
 qinterface = { path = "./qinterface", version = "0.6.0" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
-qresolve = { path = "./qresolve", version = "0.6.0" }
+qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.6.0" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.1" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.6.0" }
-dquic = { path = "./dquic", version = "0.6.0" }
+qconnection = { path = "./qconnection", version = "0.7.0-beta.1" }
+dquic = { path = "./dquic", version = "0.7.0-beta.1" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.6.0"
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.6.0"
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qresolve/Cargo.toml
+++ b/qresolve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qresolve"
-version = "0.6.0"
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "dquic's dns abstractions"
 readme.workspace = true

--- a/qresolve/src/lib.rs
+++ b/qresolve/src/lib.rs
@@ -11,7 +11,11 @@ pub use qbase::net::{Family, addr::EndpointAddr};
 pub type PublishFuture<'a> = BoxFuture<'a, io::Result<()>>;
 
 pub trait Publish: Any + Send + Sync + Display + Debug {
-    fn publish<'a>(&'a self, name: &'a str, packet: &'a [u8]) -> PublishFuture<'a>;
+    fn publish<'a>(
+        &'a self,
+        name: &'a str,
+        endpoints: &mut dyn Iterator<Item = EndpointAddr>,
+    ) -> PublishFuture<'a>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -96,9 +100,29 @@ mod tests {
     }
 
     impl Publish for TestPublisher {
-        fn publish<'a>(&'a self, _name: &'a str, _packet: &'a [u8]) -> PublishFuture<'a> {
-            async { Ok(()) }.boxed()
+        fn publish<'a>(
+            &'a self,
+            name: &'a str,
+            endpoints: &mut dyn Iterator<Item = EndpointAddr>,
+        ) -> PublishFuture<'a> {
+            let endpoints: Vec<_> = endpoints.collect();
+            async move {
+                assert_eq!(name, "demo.dhttp.net");
+                assert_eq!(endpoints.len(), 1);
+                Ok(())
+            }
+            .boxed()
         }
+    }
+
+    #[test]
+    fn publish_trait_accepts_endpoint_iterator() {
+        let publisher: &dyn Publish = &TestPublisher;
+        let endpoint = EndpointAddr::direct("203.0.113.10:4433".parse().unwrap());
+        let mut endpoints = std::iter::once(endpoint);
+
+        futures::executor::block_on(publisher.publish("demo.dhttp.net", &mut endpoints))
+            .expect("publish succeeds");
     }
 
     fn assert_send_sync<T: Send + Sync>() {}

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version.workspace = true
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepare the dquic beta release line for `v0.7.0-beta.1`.

Changed crates:

- `qresolve 0.7.0-beta.1`
- `qtraversal 0.7.0-beta.1`
- `qconnection 0.7.0-beta.1`
- `dquic 0.7.0-beta.1`

`qtraversal` and `qconnection` follow this beta line because their published dependency contract includes `qresolve`.

Unchanged crates remain on their existing versions, including `qmacro`, `qbase`, `qevent`, `qinterface`, `qprotocol`, `qdatagram`, `qcongestion`, `qrecovery`, `qudp`, and `h3-shim`.

## Release surfaces

- crates.io: `qresolve`, `qtraversal`, `qconnection`, `dquic`
- GitHub tag/release after merge: `v0.7.0-beta.1`
- Initial/incremental status: incremental prerelease updates for existing crates

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --all-targets --all-features -- -Dwarnings`
- `cargo test --workspace`
- `cargo +1.91.1 semver-checks -p qresolve --baseline-version 0.6.0 --release-type major`
- `cargo +1.91.1 semver-checks -p qtraversal --baseline-version 0.6.0 --release-type major`
- `cargo +1.91.1 semver-checks -p qconnection --baseline-version 0.6.0 --release-type major`
- `cargo +1.91.1 semver-checks -p dquic --baseline-version 0.6.0 --release-type major`
- `cargo publish --dry-run --locked -p qresolve -p qtraversal -p qconnection -p dquic`

## Downstream waits

Downstream beta PRs should wait for these crates to be published and visible on crates.io before final registry-converged merge/tag gates.
