### PR TITLE
chore: prepare dquic v0.7.0-beta.2

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -182,8 +182,15 @@ jobs:
             exit 0
           fi
 
+          release_args=()
+          version="${GITHUB_REF_NAME#v}"
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            release_args+=(--prerelease --latest=false)
+          fi
+
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "$GITHUB_REF_NAME" \
-            --notes-file "$notes_file"
+            --notes-file "$notes_file" \
+            "${release_args[@]}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,10 +104,10 @@ qinterface = { path = "./qinterface", version = "0.6.0" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.1" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.2" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
 qconnection = { path = "./qconnection", version = "0.7.0-beta.1" }
-dquic = { path = "./dquic", version = "0.7.0-beta.1" }
+dquic = { path = "./dquic", version = "0.7.0-beta.2" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/dquic/examples/echo-client.rs
+++ b/dquic/examples/echo-client.rs
@@ -84,7 +84,7 @@ async fn main() {
         .init();
 
     if let Err(error) = run(options).await {
-        tracing::error!(?error);
+        tracing::error!(target: "dquic", ?error);
         std::process::exit(1);
     };
 }
@@ -218,7 +218,7 @@ async fn send_and_verify_echo(
     let connection = client.connect(auth.host()).await?;
 
     let (sid, (reader, writer)) = connection.open_bi_stream().await?.unwrap();
-    tracing::debug!(%sid, "opened stream");
+    tracing::debug!(target: "dquic", %sid, "opened stream");
 
     let mut reader = rx_pb.wrap_async_read(reader);
     let mut writer = tx_pb.wrap_async_write(writer);

--- a/dquic/examples/echo-server.rs
+++ b/dquic/examples/echo-server.rs
@@ -78,7 +78,7 @@ async fn main() {
         .init();
 
     if let Err(error) = run(options).await {
-        tracing::info!(?error);
+        tracing::info!(target: "dquic", ?error);
         std::process::exit(1);
     }
 }
@@ -107,8 +107,8 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + 
         .await?;
 
     tracing::info!(
-        "Listening on {}",
-        listeners
+        target: "dquic",
+        listen_addr = %listeners
             .get_server(options.certs.server_name.as_str())
             .unwrap()
             .bind_interfaces()
@@ -117,7 +117,8 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + 
             .unwrap()
             .1
             .borrow()
-            .bound_addr()?
+            .bound_addr()?,
+        "listening"
     );
 
     serve_echo(listeners).await?;
@@ -128,14 +129,14 @@ async fn serve_echo(listeners: Arc<QuicListeners>) -> Result<(), ListenersShutdo
     async fn handle_stream(mut reader: StreamReader, mut writer: StreamWriter) -> io::Result<()> {
         io::copy(&mut reader, &mut writer).await?;
         writer.shutdown().await?;
-        tracing::debug!("stream copy done");
+        tracing::debug!(target: "dquic", "stream copy done");
 
         io::Result::Ok(())
     }
 
     loop {
         let (connection, _server, pathway, ..) = listeners.accept().await?;
-        info!(source = ?pathway.remote(), "accepted new connection");
+        info!(target: "dquic", source = ?pathway.remote(), "accepted new connection");
         tokio::spawn(async move {
             while let Ok((_sid, (reader, writer))) = connection.accept_bi_stream().await {
                 tokio::spawn(handle_stream(reader, writer));

--- a/dquic/examples/http-client.rs
+++ b/dquic/examples/http-client.rs
@@ -73,7 +73,7 @@ async fn main() {
         .init();
 
     if let Err(error) = run(options).await {
-        tracing::error!(?error);
+        tracing::error!(target: "dquic", ?error);
         std::process::exit(1);
     }
 }
@@ -91,10 +91,10 @@ async fn run(options: Options) -> Result<(), Error> {
     };
 
     let client_builder = if options.skip_verify {
-        tracing::warn!("skip server verify");
+        tracing::warn!(target: "dquic", "skip server verify");
         QuicClient::builder().without_verifier()
     } else {
-        tracing::info!("load ca certs");
+        tracing::info!(target: "dquic", "load ca certs");
         let mut roots = rustls::RootCertStore::empty();
         roots.add_parsable_certificates(rustls_native_certs::load_native_certs().certs);
         roots
@@ -176,6 +176,6 @@ async fn download(client: &Arc<QuicClient>, uri: Uri, save: Option<&PathBuf>) ->
 
     _ = connection.close("Bye bye", 0);
 
-    tracing::info!("Saved to file {file_path}");
+    tracing::info!(target: "dquic", %file_path, "saved response body to file");
     Ok(())
 }

--- a/dquic/examples/http-server.rs
+++ b/dquic/examples/http-server.rs
@@ -104,7 +104,7 @@ fn main() {
         .expect("failed to build tokio runtime");
 
     if let Err(error) = rt.block_on(run(options)) {
-        tracing::info!(?error);
+        tracing::info!(target: "dquic", ?error);
         std::process::exit(1);
     }
 }
@@ -132,8 +132,8 @@ async fn run(options: Options) -> Result<(), Error> {
         .await?;
 
     tracing::info!(
-        "Listening on {}",
-        listeners
+        target: "dquic",
+        listen_addr = %listeners
             .get_server(options.certs.server_name.as_str())
             .unwrap()
             .bind_interfaces()
@@ -142,7 +142,8 @@ async fn run(options: Options) -> Result<(), Error> {
             .unwrap()
             .1
             .borrow()
-            .bound_addr()?
+            .bound_addr()?,
+        "listening"
     );
 
     loop {
@@ -155,13 +156,13 @@ async fn serve_files(connection: Arc<Connection>) -> Result<(), Error> {
     async fn serve_file(mut reader: StreamReader, mut writer: StreamWriter) -> Result<(), Error> {
         let mut request = String::new();
         reader.read_to_string(&mut request).await?;
-        tracing::info!("received request: {request}");
+        tracing::info!(target: "dquic", %request, "received request");
 
         // HTTP/0.9 is very simple - just a GET request with a path
         let serve = async {
             match request.trim().strip_prefix("GET /") {
                 Some(path) => {
-                    tracing::debug!(?path, "Received HTTP/0.9 request");
+                    tracing::debug!(target: "dquic", ?path, "received HTTP/0.9 request");
                     let mut file = fs::File::open(PathBuf::from_iter(["./", path])).await?;
                     io::copy(&mut file, &mut writer).await.map(|_| ())
                 }
@@ -172,7 +173,7 @@ async fn serve_files(connection: Arc<Connection>) -> Result<(), Error> {
         };
 
         if let Err(error) = serve.await {
-            tracing::warn!("failed to serve request: {}", error);
+            tracing::warn!(target: "dquic", %error, "failed to serve request");
         }
 
         _ = writer.shutdown().await;

--- a/dquic/src/client.rs
+++ b/dquic/src/client.rs
@@ -187,7 +187,7 @@ impl QuicClient {
         };
 
         if let Err(error) = result {
-            tracing::trace!(target: "quic", ?error, "failed to feed local endpoint update to client connection");
+            tracing::trace!(target: "dquic", ?error, "failed to feed local endpoint update to client connection");
         }
     }
 
@@ -469,6 +469,7 @@ impl QuicClient {
                     }
                 }
             }
+            .in_current_span()
         });
 
         Ok(connection)

--- a/dquic/src/server.rs
+++ b/dquic/src/server.rs
@@ -426,12 +426,12 @@ impl QuicListeners {
         };
 
         if let Err(error) = result {
-            tracing::trace!(target: "quic_listeners", ?error, "failed to feed local endpoint update to accepted connection");
+            tracing::trace!(target: "dquic", ?error, "failed to feed local endpoint update to accepted connection");
         }
     }
 
     #[tracing::instrument(
-        target = "quic_listeners", level = "debug", skip_all, 
+        target = "dquic", level = "debug", skip_all,
         fields(%bind_uri, %pathway, %link, odcid=tracing::field::Empty, server_name=tracing::field::Empty)
     )]
     pub(crate) fn try_accept_connection(&self, packet: Packet, (bind_uri, pathway, link): Way) {
@@ -446,13 +446,16 @@ impl QuicListeners {
         tracing::Span::current().record("odcid", origin_dcid.to_string());
 
         if origin_dcid.is_empty() {
-            tracing::debug!(target: "quic_listeners", "Received an initial/0rtt packet with empty destination CID, ignoring it");
+            tracing::debug!(
+                target: "dquic",
+                "received an initial/0rtt packet with empty destination CID, ignoring it"
+            );
             return;
         }
 
         // Acquire a permit from the backlog semaphore to limit the number of concurrent connections.
         let Ok(premit) = self.backlog.clone().try_acquire_owned() else {
-            tracing::debug!(target: "quic_listeners", "Backlog full, dropping incoming packet");
+            tracing::debug!(target: "dquic", "backlog full, dropping incoming packet");
             return;
         };
 
@@ -492,17 +495,21 @@ impl QuicListeners {
                     let incoming = (connection, server_name, pathway, link);
                     match incomings.send((incoming, premit)).await {
                         Ok(..) => {
-                            tracing::debug!(target: "quic_listeners", "Accepted incoming connection")
+                            tracing::debug!(target: "dquic", "accepted incoming connection")
                         }
                         Err(..) => {
-                            tracing::debug!(target: "quic_listeners", "Listeners is shutdown, closing incoming connection")
+                            tracing::debug!(
+                                target: "dquic",
+                                "listeners are shut down, closing incoming connection"
+                            )
                         }
                     }
                 }
                 Err(error) => {
                     tracing::debug!(
-                        target: "quic_listeners",
-                        "Failed to accept connection: {error}",
+                        target: "dquic",
+                        %error,
+                        "failed to accept connection",
                     );
                 }
             }

--- a/dquic/tests/auth.rs
+++ b/dquic/tests/auth.rs
@@ -297,7 +297,7 @@ async fn send_and_verify_echo_with_sign_verify(
     let local = connection.local_authority().await.unwrap().unwrap();
     let remote = connection.remote_authority().await.unwrap().unwrap();
     let (_sid, (mut reader, mut writer)) = connection.open_bi_stream().await?.unwrap();
-    tracing::debug!("stream opened");
+    tracing::debug!(target: "dquic", "stream opened");
 
     let write = async {
         let data = data.to_vec();
@@ -305,7 +305,7 @@ async fn send_and_verify_echo_with_sign_verify(
         let message = postcard::to_stdvec(&Message { data, sign }).unwrap();
         writer.write_all(&message).await?;
         writer.shutdown().await?;
-        tracing::info!("write done");
+        tracing::info!(target: "dquic", "write done");
         Result::<(), BoxError>::Ok(())
     };
     let read = async {
@@ -316,7 +316,7 @@ async fn send_and_verify_echo_with_sign_verify(
             .verify(SIGNATURE_SCHEME, &message.data, &message.sign)
             .unwrap();
         assert_eq!(message.data, data);
-        tracing::info!("read done");
+        tracing::info!(target: "dquic", "read done");
         Result::<(), BoxError>::Ok(())
     };
 
@@ -333,13 +333,13 @@ async fn echo_stream_with_sign_verify(
     reader.read_to_end(&mut message).await.unwrap();
     let Message { data, sign } = postcard::from_bytes(&message).unwrap();
     remote.verify(SIGNATURE_SCHEME, &data, &sign).unwrap();
-    tracing::debug!("message received and verified");
+    tracing::debug!(target: "dquic", "message received and verified");
 
     let sign = local.sign(SIGNATURE_SCHEME, &data).unwrap();
     let message = postcard::to_stdvec(&Message { data, sign }).unwrap();
     writer.write_all(&message).await.unwrap();
     writer.shutdown().await.unwrap();
-    tracing::debug!("signed echo sent");
+    tracing::debug!(target: "dquic", "signed echo sent");
 }
 
 pub async fn serve_echo_with_sign_verify(listeners: Arc<QuicListeners>) {
@@ -347,7 +347,7 @@ pub async fn serve_echo_with_sign_verify(listeners: Arc<QuicListeners>) {
         assert_eq!(server, "localhost");
         let local = connection.local_authority().await.unwrap().unwrap();
         let remote = connection.remote_authority().await.unwrap().unwrap();
-        tracing::info!(source = ?pathway.remote(),"accepted new connection");
+        tracing::info!(target: "dquic", source = ?pathway.remote(), "accepted new connection");
         tokio::spawn(async move {
             while let Ok((_sid, (reader, writer))) = connection.accept_bi_stream().await {
                 tokio::spawn(echo_stream_with_sign_verify(

--- a/dquic/tests/echo.rs
+++ b/dquic/tests/echo.rs
@@ -82,7 +82,7 @@ fn shutdown() -> Result<(), BoxError> {
         async fn serve_only_one_stream(listeners: Arc<QuicListeners>) {
             while let Ok((connection, server, pathway, _link)) = listeners.accept().await {
                 assert_eq!(server, "localhost");
-                tracing::info!(source = ?pathway.remote(), "accepted new connection");
+                tracing::info!(target: "dquic", source = ?pathway.remote(), "accepted new connection");
                 tokio::spawn(async move {
                     let (_sid, (reader, writer)) = connection.accept_bi_stream().await?;
                     echo_stream(reader, writer).await;
@@ -250,7 +250,7 @@ fn double_connections() -> Result<(), BoxError> {
                 .await?;
             connections.spawn(
                 async move { send_and_verify_echo(&connection, TEST_DATA).await }
-                    .instrument(tracing::info_span!("stream", conn_idx)),
+                    .instrument(tracing::info_span!(target: "dquic", "stream", conn_idx)),
             );
         }
 
@@ -298,18 +298,19 @@ fn parallel_stream() -> Result<(), BoxError> {
         let mut streams = JoinSet::new();
 
         for conn_idx in 0..PARALLEL_ECHO_CONNS {
-            tracing::info!(conn_idx, "Starting connection");
+            tracing::info!(target: "dquic", conn_idx, "starting connection");
             let connection = Arc::new(
                 client
                     .connected_to_with_source("localhost", [(Source::System, server_addr.into())])
                     .await?,
             );
-            tracing::info!(conn_idx, "Connected");
+            tracing::info!(target: "dquic", conn_idx, "connected");
             for stream_idx in 0..PARALLEL_ECHO_STREAMS {
                 let connection = connection.clone();
                 streams.spawn(
-                    async move { send_and_verify_echo(&connection, TEST_DATA).await }
-                        .instrument(tracing::info_span!("stream", conn_idx, stream_idx)),
+                    async move { send_and_verify_echo(&connection, TEST_DATA).await }.instrument(
+                        tracing::info_span!(target: "dquic", "stream", conn_idx, stream_idx),
+                    ),
                 );
             }
         }
@@ -364,7 +365,7 @@ fn parallel_big_stream() -> Result<(), BoxError> {
             let test_data = test_data.clone();
             big_streams.spawn(
                 async move { send_and_verify_echo(&connection, &test_data).await }
-                    .instrument(tracing::info_span!("stream", conn_idx)),
+                    .instrument(tracing::info_span!(target: "dquic", "stream", conn_idx)),
             );
         }
 
@@ -438,8 +439,9 @@ fn limited_streams() -> Result<(), BoxError> {
             for stream_idx in 0..PARALLEL_ECHO_STREAMS / 2 {
                 let connection = connection.clone();
                 streams.spawn(
-                    async move { send_and_verify_echo(&connection, TEST_DATA).await }
-                        .instrument(tracing::info_span!("stream", conn_idx, stream_idx)),
+                    async move { send_and_verify_echo(&connection, TEST_DATA).await }.instrument(
+                        tracing::info_span!(target: "dquic", "stream", conn_idx, stream_idx),
+                    ),
                 );
             }
         }

--- a/dquic/tests/echo_common/mod.rs
+++ b/dquic/tests/echo_common/mod.rs
@@ -11,13 +11,13 @@ use crate::common::{BoxError, SERVER_CERT, SERVER_KEY, qlogger};
 pub async fn echo_stream(mut reader: StreamReader, mut writer: StreamWriter) {
     io::copy(&mut reader, &mut writer).await.unwrap();
     _ = writer.shutdown().await;
-    tracing::debug!("stream copy done");
+    tracing::debug!(target: "dquic", "stream copy done");
 }
 
 pub async fn serve_echo(listeners: Arc<QuicListeners>) {
     while let Ok((connection, server, pathway, _link)) = listeners.accept().await {
         assert_eq!(server, "localhost");
-        tracing::info!(source = ?pathway.remote(), "accepted new connection");
+        tracing::info!(target: "dquic", source = ?pathway.remote(), "accepted new connection");
         tokio::spawn(async move {
             while let Ok((_sid, (reader, writer))) = connection.accept_bi_stream().await {
                 tokio::spawn(echo_stream(reader, writer));
@@ -28,20 +28,20 @@ pub async fn serve_echo(listeners: Arc<QuicListeners>) {
 
 pub async fn send_and_verify_echo(connection: &Connection, data: &[u8]) -> Result<(), BoxError> {
     let (_sid, (mut reader, mut writer)) = connection.open_bi_stream().await?.unwrap();
-    tracing::debug!("stream opened");
+    tracing::debug!(target: "dquic", "stream opened");
 
     let mut back = Vec::new();
     tokio::try_join!(
         async {
             writer.write_all(data).await?;
             writer.shutdown().await?;
-            tracing::info!("write done");
+            tracing::info!(target: "dquic", "write done");
             Result::<(), BoxError>::Ok(())
         },
         async {
             reader.read_to_end(&mut back).await?;
             assert_eq!(back, data);
-            tracing::info!("read done");
+            tracing::info!(target: "dquic", "read done");
             Result::<(), BoxError>::Ok(())
         }
     )

--- a/dquic/tests/traversal.rs
+++ b/dquic/tests/traversal.rs
@@ -110,6 +110,7 @@ macro_rules! test_punch_matrix {
         fn $test_name() {
             run(async move {
                 let span = tracing::info_span!(
+                    target: "dquic",
                     stringify!($test_name),
                     client = stringify!($client),
                     server = stringify!($server)
@@ -180,7 +181,7 @@ async fn launch_stun_test_server(server_case: TestCase) -> Arc<QuicListeners> {
         .await
         .unwrap();
 
-    info!("Server listening on {server_addr}");
+    info!(target: "dquic", %server_addr, "server listening");
 
     tokio::spawn(serve_echo(listeners.clone()));
 
@@ -217,7 +218,7 @@ async fn launch_stun_test_client(client_case: TestCase) -> Arc<QuicClient> {
         .with_qlog(qlogger())
         .build();
 
-    info!("Client bound on {client_addr}");
+    info!(target: "dquic", %client_addr, "client bound");
 
     Arc::new(client)
 }
@@ -237,15 +238,15 @@ async fn test_punch_case(client_nat: NatType, server_nat: NatType) {
     let client_case = CLIENT_CASES[&client_nat];
     let server_case = SERVER_CASES[&server_nat];
 
-    info!("Testing punch case: client {client_nat:?} <-> server {server_nat:?}",);
+    info!(target: "dquic", ?client_nat, ?server_nat, "testing punch case");
 
     if client_nat == NatType::Dynamic || server_nat == NatType::Dynamic {
-        warn!("Skipping Dynamic NAT test case");
+        warn!(target: "dquic", "skipping Dynamic NAT test case");
         // TODO: Dynamic NAT 模拟有问题
         return;
     }
     if client_nat == NatType::Symmetric && server_nat == NatType::Symmetric {
-        warn!("Skipping Symmetric NAT to Symmetric NAT test case");
+        warn!(target: "dquic", "skipping Symmetric NAT to Symmetric NAT test case");
         // Symmetric NAT 互穿不通
         return;
     }
@@ -326,7 +327,7 @@ async fn launch_client(client_case: TestCase, server_ep: EndpointAddr) {
         .await
         .unwrap();
     let odcid = connection.origin_dcid().expect("connection failed");
-    tracing::info!(%odcid, "connected to server");
+    tracing::info!(target: "dquic", %odcid, "connected to server");
     let test_data = Arc::new(TEST_DATA.to_vec());
 
     // 循环检查直连路径，每秒检查一次
@@ -347,12 +348,12 @@ async fn launch_client(client_case: TestCase, server_ep: EndpointAddr) {
             .any(|pathway| matches!(pathway.local(), EndpointAddr::Direct { .. }));
 
         if has_direct {
-            tracing::info!("Direct path established: {:?}", paths);
+            tracing::info!(target: "dquic", ?paths, "direct path established");
             return;
         }
 
         // 没有直连路径，执行 echo 测试确保连接正常
-        tracing::debug!("no direct path yet, verifying connection with echo test");
+        tracing::debug!(target: "dquic", "no direct path yet, verifying connection with echo test");
         send_and_verify_echo(&connection, &test_data)
             .await
             .expect("echo test failed");

--- a/h3-shim/examples/h3-client.rs
+++ b/h3-shim/examples/h3-client.rs
@@ -109,7 +109,7 @@ async fn main() {
         )
         .init();
     if let Err(error) = run(options).await {
-        tracing::error!(?error);
+        tracing::error!(target: "dquic", ?error);
         std::process::exit(1);
     };
 }
@@ -123,10 +123,10 @@ async fn run(options: Options) -> Result<(), Error> {
     };
 
     let client_builder = if options.skip_verify {
-        tracing::warn!("skip server verify");
+        tracing::warn!(target: "dquic", "skip server verify");
         QuicClient::builder().without_verifier()
     } else {
-        tracing::info!("load ca certs");
+        tracing::info!(target: "dquic", "load ca certs");
         let mut roots = rustls::RootCertStore::empty();
         roots.add_parsable_certificates(rustls_native_certs::load_native_certs().certs);
         roots
@@ -228,7 +228,7 @@ async fn download_files_with_progress(
 ) -> Result<usize, Error> {
     let quic_connection = client.connect(authority.host()).await?;
     let odcid = quic_connection.origin_dcid()?;
-    let span = tracing::info_span!("requests", %odcid, host = authority.host());
+    let span = tracing::info_span!(target: "dquic", "requests", %odcid, host = authority.host());
 
     let (mut connection, send_request) =
         h3::client::new(h3_shim::QuicConnection::new(quic_connection.clone()))

--- a/h3-shim/examples/h3-server.rs
+++ b/h3-shim/examples/h3-server.rs
@@ -99,7 +99,7 @@ fn main() {
         .init();
 
     // 测试日志是否工作
-    tracing::info!("tracing initialized successfully");
+    tracing::info!(target: "dquic", "tracing initialized successfully");
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -109,13 +109,13 @@ fn main() {
         .expect("failed to build tokio runtime");
 
     if let Err(error) = rt.block_on(run(options)) {
-        tracing::info!(?error);
+        tracing::info!(target: "dquic", ?error);
         std::process::exit(1);
     }
 }
 
 async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    tracing::info!("Serving {}", options.root.display());
+    tracing::info!(target: "dquic", root = %options.root.display(), "serving files");
     let root = Arc::new(options.root);
     if !root.is_dir() {
         return Err(format!("{}: is not a readable directory", root.display()).into());
@@ -148,8 +148,8 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + 
         )
         .await?;
     tracing::info!(
-        "Listening on {}",
-        listeners
+        target: "dquic",
+        listen_addr = %listeners
             .get_server(server_name.as_str())
             .unwrap()
             .bind_interfaces()
@@ -158,7 +158,8 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + 
             .unwrap()
             .1
             .borrow()
-            .bound_addr()?
+            .bound_addr()?,
+        "listening"
     );
 
     // handle incoming connections and requests
@@ -166,11 +167,11 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error + Send + 
         let h3_conn =
             match h3::server::Connection::new(h3_shim::QuicConnection::new(new_conn)).await {
                 Ok(h3_conn) => {
-                    tracing::info!("accept a new quic connection");
+                    tracing::info!(target: "dquic", "accepted new QUIC connection");
                     h3_conn
                 }
                 Err(error) => {
-                    tracing::error!("failed to establish h3 connection: {}", error);
+                    tracing::error!(target: "dquic", %error, "failed to establish h3 connection");
                     continue;
                 }
             };
@@ -198,7 +199,7 @@ async fn handle_connection<T>(
                 };
                 tokio::spawn(async move {
                     if let Err(e) = handle_request.await {
-                        tracing::error!("handling request failed: {}", e);
+                        tracing::error!(target: "dquic", error = %e, "handling request failed");
                     }
                 });
             }
@@ -224,7 +225,7 @@ where
             match File::open(&to_serve).await {
                 Ok(file) => (StatusCode::OK, Some(file)),
                 Err(e) => {
-                    tracing::error!("failed to open: \"{}\": {}", to_serve.to_string_lossy(), e);
+                    tracing::error!(target: "dquic", path = %to_serve.to_string_lossy(), error = %e, "failed to open file");
                     (StatusCode::NOT_FOUND, None)
                 }
             }

--- a/qbase/src/net/tx.rs
+++ b/qbase/src/net/tx.rs
@@ -180,6 +180,8 @@ mod tests {
         }
     }
 
+    use tracing::Instrument as _;
+
     use super::*;
 
     #[tokio::test]
@@ -196,6 +198,7 @@ mod tests {
                     wake_times.fetch_add(1, Release);
                 }
             }
+            .in_current_span()
         });
 
         waker.wake_by(Signals::FLOW_CONTROL);
@@ -225,6 +228,7 @@ mod tests {
                     wake_times.fetch_add(1, Release);
                 }
             }
+            .in_current_span()
         });
 
         let wait_for_all_cond_state = !Signals::all().bits();
@@ -261,6 +265,7 @@ mod tests {
                     wake_times.fetch_add(1, Release);
                 }
             }
+            .in_current_span()
         });
 
         let wait_for_quota_state = !Signals::CONGESTION.bits();
@@ -293,6 +298,7 @@ mod tests {
                 wait_for(Signals::CONGESTION | Signals::TRANSPORT).await;
                 wait_for(Signals::TRANSPORT).await;
             }
+            .in_current_span()
         });
 
         let wait_for_all_cond_state = !Signals::all().bits();
@@ -343,6 +349,7 @@ mod tests {
                     waker.wait_for(Signals::TRANSPORT).await;
                 }
             }
+            .in_current_span()
         });
 
         tokio::task::yield_now().await;
@@ -374,6 +381,7 @@ mod tests {
                     waker.wait_for(Signals::CONGESTION).await;
                 }
             }
+            .in_current_span()
         });
 
         tokio::task::yield_now().await;

--- a/qbase/src/packet.rs
+++ b/qbase/src/packet.rs
@@ -188,7 +188,7 @@ impl Iterator for PacketReader {
         match io::be_packet(&mut self.raw_bytes, self.dcid_len) {
             Ok(packet) => Some(Ok(packet)),
             Err(error) => {
-                tracing::debug!(target: "quic", ?error, "dropped unparsed packet");
+                tracing::debug!(target: "dquic", ?error, "dropped unparsed packet");
                 self.raw_bytes.clear(); // no longer parsing
                 Some(Err(error))
             }

--- a/qbase/src/param/io.rs
+++ b/qbase/src/param/io.rs
@@ -163,7 +163,7 @@ impl<R: IntoRole + RequiredParameters + Default> Parameters<R> {
             let param_id = match ParameterId::try_from(param_id) {
                 Ok(param_id) => param_id,
                 Err(unknown @ Error::UnknownParameterId(..)) => {
-                    tracing::warn!(target: "quic", "{unknown}, ignore");
+                    tracing::debug!(target: "dquic", %unknown, "ignore unknown transport parameter");
                     continue; // Ignore unknown parameters
                 }
                 Err(e) => return Err(e.into()),
@@ -196,7 +196,7 @@ impl ServerParameters {
             let param_id = match ParameterId::try_from(param_id) {
                 Ok(param_id) => param_id,
                 Err(unknown @ Error::UnknownParameterId(..)) => {
-                    tracing::warn!(target: "quic", "{unknown}, ignore");
+                    tracing::debug!(target: "dquic", %unknown, "ignore unknown transport parameter");
                     continue; // Ignore unknown parameters
                 }
                 Err(e) => return Err(e.into()),

--- a/qbase/src/util/async_deque.rs
+++ b/qbase/src/util/async_deque.rs
@@ -323,6 +323,7 @@ impl<T> Extend<T> for &ArcAsyncDeque<T> {
 #[cfg(test)]
 mod tests {
     use futures::FutureExt;
+    use tracing::Instrument as _;
 
     use super::*;
 
@@ -410,10 +411,10 @@ mod tests {
     async fn racing() {
         let deque: ArcAsyncDeque<()> = ArcAsyncDeque::new();
 
-        let consumer = tokio::spawn(deque.pop());
+        let consumer = tokio::spawn(deque.pop().in_current_span());
         tokio::task::yield_now().await;
 
-        let abuse = tokio::spawn(deque.pop());
+        let abuse = tokio::spawn(deque.pop().in_current_span());
         tokio::task::yield_now().await;
 
         // willnot be waked up

--- a/qbase/src/util/bound_queue.rs
+++ b/qbase/src/util/bound_queue.rs
@@ -62,6 +62,8 @@ impl<T> BoundQueue<T> {
 #[cfg(test)]
 mod tests {
 
+    use tracing::Instrument as _;
+
     use super::*;
 
     #[tokio::test]
@@ -74,6 +76,7 @@ mod tests {
                 assert!(queue.send(1).await.is_ok());
                 assert!(queue.send(2).await.is_ok());
             }
+            .in_current_span()
         });
 
         assert_eq!(queue.recv().await, Some(1));

--- a/qcongestion/src/rtt.rs
+++ b/qcongestion/src/rtt.rs
@@ -101,7 +101,11 @@ impl Rtt {
             .mul_f32(TIME_THRESHOLD)
             .min(MAX_INITIAL_RTT);
         self.rttvar = self.smoothed_rtt / 2;
-        tracing::trace!(target: "quic", "Back off initial RTT {}ms", self.smoothed_rtt.as_millis());
+        tracing::trace!(
+            target: "dquic",
+            smoothed_rtt_ms = self.smoothed_rtt.as_millis(),
+            "back off initial RTT"
+        );
     }
 }
 

--- a/qconnection/src/builder.rs
+++ b/qconnection/src/builder.rs
@@ -460,11 +460,16 @@ impl PendingConnection {
 
         let group_id = GroupID::from(self.origin_dcid);
         let qlog_span = self.qlogger.new_trace(self.role.into(), group_id.clone());
-        let tracing_span =
-            tracing::debug_span!(parent: None, "connection", role = %self.role, odcid = %group_id);
+        let tracing_span = tracing::debug_span!(
+            target: "dquic",
+            parent: None,
+            "connection",
+            role = %self.role,
+            odcid = %group_id
+        );
         let _span = (qlog_span.enter(), tracing_span.clone().entered());
 
-        tracing::trace!(parameters=?self.parameters, "starting new connection");
+        tracing::trace!(target: "dquic", parameters = ?self.parameters, "starting new connection");
 
         let conn_state = ArcConnState::new();
         let event_broker = ArcEventBroker::new(conn_state.clone(), event_broker);
@@ -666,9 +671,9 @@ fn tls_fin_handler(
         if parameters.role() == Role::Client {
             if zero_rtt_rejected {
                 debug_assert_eq!(parameters.role(), Role::Client);
-                tracing::trace!(target: "quic", "0-RTT is not enabled, or not accepted by the server.");
+                tracing::trace!(target: "dquic", "0-RTT is not enabled or not accepted by the server");
             } else {
-                tracing::trace!(target: "quic", "0-RTT is enabled and accepted by the server.");
+                tracing::trace!(target: "dquic", "0-RTT is enabled and accepted by the server");
             }
         }
 

--- a/qconnection/src/events.rs
+++ b/qconnection/src/events.rs
@@ -61,7 +61,7 @@ impl EmitEvent for ArcEventBroker {
             }
             Event::StatelessReset => todo!("unsupported"),
         };
-        tracing::debug!(target: "quic", new_state = ?event, "connection state changed");
+        tracing::debug!(target: "dquic", new_state = ?event, "connection state changed");
         self.raw_broker.emit(event);
     }
 }

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -764,9 +764,9 @@ impl Drop for Connection {
         let error = AppError::new(0_u64.try_into().expect("zero app error code"), "");
         if self.application_close(error, false).is_ok() {
             #[cfg(debug_assertions)]
-            tracing::warn!(target: "quic", "connection is still active when dropped, close it automatically.");
+            tracing::warn!(target: "dquic", "connection is still active when dropped, closing it automatically");
             #[cfg(not(debug_assertions))]
-            tracing::debug!(target: "quic", "connection is still active when dropped, close it automatically.");
+            tracing::debug!(target: "dquic", "connection is still active when dropped, closing it automatically");
         }
     }
 }

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -179,7 +179,7 @@ impl Components {
                 Instrument::instrument(task, qevent::span!(@current, path=pathway.to_string()))
                     .in_current_span();
 
-            tracing::trace!(target: "quic", %pathway, %link, is_probed, is_initial_path, "add new path");
+            tracing::trace!(target: "dquic", %pathway, %link, is_probed, is_initial_path, "add new path");
 
             Ok((path, task))
         };

--- a/qconnection/src/path/burst.rs
+++ b/qconnection/src/path/burst.rs
@@ -570,7 +570,12 @@ impl Burst {
                             &self.path.pathway,
                             payload,
                         );
-                        tracing::trace!(?forward_hdr, link=%self.path.link(),"put forward header");
+                        tracing::trace!(
+                            target: "dquic",
+                            ?forward_hdr,
+                            link = %self.path.link(),
+                            "put forward header"
+                        );
                         header.put_forward_header(&forward_hdr);
                     }
                     reversed_size + packet_size

--- a/qconnection/src/path/paths.rs
+++ b/qconnection/src/path/paths.rs
@@ -93,6 +93,7 @@ impl ArcPathContexts {
         let mut state = self.state.write().unwrap();
         if !state.accepting_paths {
             tracing::trace!(
+                target: "dquic",
                 pathway = %path.pathway,
                 initial_dcid = %initial_dcid,
                 "ignored handshake path assignment after path contexts closed"
@@ -101,6 +102,7 @@ impl ArcPathContexts {
         }
         if state.initial_path.is_some() {
             tracing::trace!(
+                target: "dquic",
                 pathway = %path.pathway,
                 initial_dcid = %initial_dcid,
                 "handshake path already assigned"
@@ -110,6 +112,7 @@ impl ArcPathContexts {
         remote_cids.apply_initial_dcid(initial_dcid, &path.dcid_cell);
         state.initial_path = Some(Arc::downgrade(path));
         tracing::debug!(
+            target: "dquic",
             pathway = %path.pathway,
             initial_dcid = %initial_dcid,
             "assigned handshake path"
@@ -175,7 +178,7 @@ impl ArcPathContexts {
 
     pub fn remove(&self, pathway: &Pathway, reason: &PathDeactivated) {
         if self.paths.remove(pathway).is_some() {
-            tracing::debug!(target: "quic", %pathway, %reason, "path deactivated");
+            tracing::debug!(target: "dquic", %pathway, %reason, "path deactivated");
             if self.state.read().unwrap().accepting_paths && self.is_empty() {
                 let error = QuicError::with_default_fty(
                     ErrorKind::NoViablePath,
@@ -266,10 +269,13 @@ mod tests {
         let entry = PathSendWakerEntry::insert(pathway, &tx_wakers, &send_waker);
 
         let (done_tx, done_rx) = oneshot::channel();
-        let waiter = tokio::spawn(async move {
-            send_waker.wait_for(Signals::PING).await;
-            _ = done_tx.send(());
-        });
+        let waiter = tokio::spawn(
+            async move {
+                send_waker.wait_for(Signals::PING).await;
+                _ = done_tx.send(());
+            }
+            .in_current_span(),
+        );
         tokio::task::yield_now().await;
 
         drop(entry);

--- a/qconnection/src/path/validate.rs
+++ b/qconnection/src/path/validate.rs
@@ -31,7 +31,7 @@ impl super::Path {
                 Ok(Some(response)) if *response == *challenge => {
                     self.validated();
                     self.anti_amplifier.grant();
-                    tracing::debug!(target: "quic", pathway=%self.pathway, "path validated successfully");
+                    tracing::debug!(target: "dquic", pathway=%self.pathway, "path validated successfully");
                     return Ok(());
                 }
                 // 外部发生变化，导致路径验证任务作废

--- a/qconnection/src/space/initial.rs
+++ b/qconnection/src/space/initial.rs
@@ -194,6 +194,7 @@ async fn parse_normal_packet(
     let remote_cids = &components.cid_registry.remote;
 
     tracing::trace!(
+        target: "dquic",
         %bind_uri,
         %pathway,
         %link,

--- a/qconnection/src/tls.rs
+++ b/qconnection/src/tls.rs
@@ -353,7 +353,11 @@ impl ServerTlsSession {
         {
             ClientNameVerifyResult::Accept => {
                 self.send_lock.grant_permit();
-                tracing::debug!(?client_name);
+                tracing::debug!(
+                    target: "dquic",
+                    client_name = ?client_name.as_deref(),
+                    "client name verification accepted"
+                );
                 self.client_name = client_name.map(Arc::from);
                 parameters.lock_guard()?.recv_remote_params(client_params)?;
 
@@ -367,9 +371,9 @@ impl ServerTlsSession {
             ClientNameVerifyResult::Refuse(reason) => {
                 self.send_lock.grant_permit();
                 tracing::debug!(
-                    target: "quic",
+                    target: "dquic",
                     server_name = %server_authority.name(),
-                    client_name = ?self.client_name.as_deref(),
+                    client_name = ?client_name.as_deref(),
                     ?reason,
                     "client name verification failed, refusing connection"
                 );
@@ -380,9 +384,9 @@ impl ServerTlsSession {
             }
             ClientNameVerifyResult::SilentRefuse(reason) => {
                 tracing::debug!(
-                    target: "quic",
+                    target: "dquic",
                     server_name = %server_authority.name(),
-                    client_name = ?self.client_name.as_deref(),
+                    client_name = ?client_name.as_deref(),
                     ?reason,
                     "client name verification failed, refusing connection silently"
                 );
@@ -418,7 +422,7 @@ impl ServerTlsSession {
             }
             ClientAuthorityVerifyResult::Refuse(reason) => {
                 tracing::debug!(
-                    target: "quic",
+                    target: "dquic",
                     server_name = %server_authority.name(),
                     ?self.client_name,
                     ?reason,
@@ -621,7 +625,7 @@ impl ArcTlsHandshake {
 
         if tls_handshake.session.is_finished() && tls_handshake.info.get().is_none() {
             let info = Arc::new(tls_handshake.session.r#yield());
-            tracing::debug!(target: "quic", "tls handshake finished");
+            tracing::debug!(target: "dquic", "tls handshake finished");
             tls_handshake.info.set(info.clone());
             return Ok(Some(info));
         }

--- a/qconnection/src/traversal.rs
+++ b/qconnection/src/traversal.rs
@@ -68,12 +68,12 @@ impl Components {
 
     // 添加对端直通地址，可以直接新建 path
     pub fn add_peer_endpoint(&self, addr: EndpointAddr, source: qresolve::Source) {
-        tracing::trace!(target: "quic", %addr, ?source, "add peer endpoint");
+        tracing::trace!(target: "dquic", %addr, ?source, "add peer endpoint");
         let source_for_log = source.clone();
         match self.puncher.add_peer_endpoint(addr, source) {
             Ok(ways) => {
                 tracing::trace!(
-                    target: "quic",
+                    target: "dquic",
                     %addr,
                     source = ?source_for_log,
                     path_count = ways.len(),
@@ -86,7 +86,7 @@ impl Components {
                 });
             }
             Err(error) => {
-                tracing::warn!(target: "quic", ?error, "add peer endpoint failed");
+                tracing::warn!(target: "dquic", ?error, "add peer endpoint failed");
             }
         }
     }

--- a/qevent/src/legacy/exporter.rs
+++ b/qevent/src/legacy/exporter.rs
@@ -16,7 +16,7 @@ impl IoExpoter {
         O: AsyncWrite + Unpin + Send + 'static,
     {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        tokio::spawn(tracing::Instrument::in_current_span(async move {
             let task = async {
                 const RS: u8 = 0x1E;
 
@@ -42,10 +42,10 @@ impl IoExpoter {
                     target: "qlog",
                     ?error,
                     ?qlog_file_seq,
-                    "Failed to write qlog, subsequent qlogs in this exporter will be ignored."
+                    "failed to write qlog, subsequent qlogs in this exporter will be ignored"
                 );
             }
-        });
+        }));
         Self(tx)
     }
 }

--- a/qevent/src/telemetry/handy.rs
+++ b/qevent/src/telemetry/handy.rs
@@ -135,7 +135,7 @@ impl<S: TelemetryStorage> QLog for LegacySeqLogger<S> {
         });
 
         let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
-        tokio::spawn(async move {
+        tokio::spawn(tracing::Instrument::in_current_span(async move {
             let mut log_file = io::BufWriter::new(file.await);
 
             const RS: u8 = 0x1E;
@@ -157,7 +157,7 @@ impl<S: TelemetryStorage> QLog for LegacySeqLogger<S> {
             }
 
             log_file.shutdown().await
-        });
+        }));
 
         crate::span!(Arc::new(tx), group_id = group_id)
     }
@@ -169,8 +169,13 @@ impl QLog for TracingLogger {
     fn new_trace(&self, vantage_point: VantagePointType, group_id: GroupID) -> Span {
         use crate::legacy;
 
-        let span =
-            tracing::info_span!(parent: None,"qlog", role = %vantage_point, odcid = %group_id);
+        let span = tracing::info_span!(
+            target: "qlog",
+            parent: None,
+            "qlog",
+            role = %vantage_point,
+            odcid = %group_id
+        );
 
         let qlog_file_seq = crate::build!(legacy::QlogFileSeq {
             title: format!("{group_id}_{vantage_point}.sqlog"),

--- a/qinterface/src/component/alive.rs
+++ b/qinterface/src/component/alive.rs
@@ -11,6 +11,7 @@ use qbase::net::route::{Line, Link, Route};
 use thiserror::Error;
 use tokio::net::UdpSocket;
 use tokio_util::task::AbortOnDropHandle;
+use tracing::Instrument as _;
 
 use crate::{
     Interface, RebindedError,
@@ -129,25 +130,28 @@ impl RebindOnNetworkChangedComponent {
         let device = device.to_owned();
         let weak_iface = iface.bind_interface().downgrade();
         let mut event_receiver = self.devices.event_receiver();
-        *task = Some(AbortOnDropHandle::new(tokio::spawn(async move {
-            let try_rebind = async move || {
-                if let Ok(iface) = weak_iface.upgrade()
-                    && let Err(error) = is_alive(&iface.borrow()).await
-                    && error.is_recoverable()
-                    && !RebindedError::is_source_of(&error)
-                {
-                    iface.rebind().await;
-                }
-            };
+        *task = Some(AbortOnDropHandle::new(tokio::spawn(
+            async move {
+                let try_rebind = async move || {
+                    if let Ok(iface) = weak_iface.upgrade()
+                        && let Err(error) = is_alive(&iface.borrow()).await
+                        && error.is_recoverable()
+                        && !RebindedError::is_source_of(&error)
+                    {
+                        iface.rebind().await;
+                    }
+                };
 
-            try_rebind().await;
-            while let Some(event) = event_receiver.recv().await {
-                if event.device() != device {
-                    continue;
-                }
                 try_rebind().await;
+                while let Some(event) = event_receiver.recv().await {
+                    if event.device() != device {
+                        continue;
+                    }
+                    try_rebind().await;
+                }
             }
-        })));
+            .in_current_span(),
+        )));
     }
 }
 

--- a/qinterface/src/component/local_endpoint.rs
+++ b/qinterface/src/component/local_endpoint.rs
@@ -578,7 +578,7 @@ impl<I: RefIO + 'static> CurrentInterfaceLocalEndpoints<I> {
         let mut direct = match publishers.direct_endpoint_publisher() {
             Ok(direct) => Some(direct),
             Err(error) => {
-                tracing::debug!(target: "quic", ?error, "failed to claim direct endpoint publisher");
+                tracing::debug!(target: "dquic", ?error, "failed to claim direct endpoint publisher");
                 None
             }
         };
@@ -588,6 +588,7 @@ impl<I: RefIO + 'static> CurrentInterfaceLocalEndpoints<I> {
             }
             (_, Err(error)) => {
                 tracing::trace!(
+                    target: "dquic",
                     bind_uri = %bind_uri,
                     ?error,
                     "local interface has no direct endpoint"
@@ -595,6 +596,7 @@ impl<I: RefIO + 'static> CurrentInterfaceLocalEndpoints<I> {
             }
             (None, Ok(addr)) => {
                 tracing::trace!(
+                    target: "dquic",
                     bind_uri = %bind_uri,
                     %addr,
                     "direct endpoint publisher unavailable"

--- a/qinterface/src/device.rs
+++ b/qinterface/src/device.rs
@@ -19,6 +19,7 @@ use tokio::{
     time::MissedTickBehavior,
 };
 use tokio_util::task::AbortOnDropHandle;
+use tracing::Instrument as _;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -353,6 +354,7 @@ impl Devices {
                     state.check_network_changes();
                 }
             }
+            .in_current_span()
         }));
 
         let watcher = netwatcher::watch_interfaces_with_callback({

--- a/qinterface/src/manager.rs
+++ b/qinterface/src/manager.rs
@@ -125,6 +125,7 @@ impl InterfaceManager {
                         }
 
                         tracing::debug!(
+                            target: "interface",
                             bind_uri = %bind_uri,
                             "replacing closed interface binding during bind"
                         );
@@ -230,6 +231,7 @@ impl Binding {
     fn new(io: Box<dyn IO>, id: UniqueId) -> Self {
         let bind_uri = io.bind_uri();
         let span = tracing::debug_span!(
+            target: "interface",
             parent: None,
             "interface",
             %bind_uri,
@@ -325,6 +327,7 @@ impl BindInterface {
             ready!(context.factory.poll_rebind(cx, &mut binding.io));
             binding.id = context.ifaces.bind_id_generator.generate();
             binding.span = tracing::debug_span!(
+                target: "interface",
                 parent: None,
                 "interface",
                 bind_uri = %binding.io.bind_uri(),

--- a/qrecovery/src/journal/sent.rs
+++ b/qrecovery/src/journal/sent.rs
@@ -144,7 +144,7 @@ impl SentPktState {
                 if expire_time > now {
                     true
                 } else {
-                    tracing::trace!(target: "quic", "retransmitted packet {pn} is expired without ack");
+                    tracing::trace!(target: "dquic", "retransmitted packet {pn} is expired without ack");
                     false
                 }
             }

--- a/qrecovery/src/recv/reader.rs
+++ b/qrecovery/src/recv/reader.rs
@@ -255,28 +255,28 @@ impl<TX> Drop for Reader<TX> {
                 Recver::Recv(r) if !r.is_stopped() => {
                     #[cfg(debug_assertions)]
                     tracing::warn!(
-                        target: "quic",
-                        "The receiving {} is not stopped with error before dropped!",
+                        target: "dquic",
+                        "receiving stream {} is not stopped before drop",
                         r.stream_id(),
                     );
                     #[cfg(not(debug_assertions))]
                     tracing::debug!(
-                        target: "quic",
-                        "The receiving {} is not stopped with error before dropped!",
+                        target: "dquic",
+                        "receiving stream {} is not stopped before drop",
                         r.stream_id(),
                     );
                 }
                 Recver::SizeKnown(r) if !r.is_stopped() => {
                     #[cfg(debug_assertions)]
                     tracing::warn!(
-                        target: "quic",
-                        "The receiving {} is not stopped with error before dropped!",
+                        target: "dquic",
+                        "receiving stream {} is not stopped before drop",
                         r.stream_id()
                     );
                     #[cfg(not(debug_assertions))]
                     tracing::debug!(
-                        target: "quic",
-                        "The receiving {} is not stopped with error before dropped!",
+                        target: "dquic",
+                        "receiving stream {} is not stopped before drop",
                         r.stream_id()
                     );
                 }

--- a/qrecovery/src/send/sender.rs
+++ b/qrecovery/src/send/sender.rs
@@ -218,7 +218,7 @@ where
             VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
         );
         tracing::debug!(
-            target: "quic",
+            target: "dquic",
             "{} is canceled by app layer, with error code {err_code}",
             self.stream_id
         );
@@ -435,7 +435,7 @@ where
             VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
         );
         tracing::debug!(
-            target: "quic",
+            target: "dquic",
             "{} is canceled by app layer, with error code {err_code}",
             self.stream_id
         );
@@ -578,7 +578,7 @@ where
             VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
         );
         tracing::debug!(
-            target: "quic",
+            target: "dquic",
             "{} is canceled by app layer, with error code {err_code}",
             self.stream_id
         );

--- a/qrecovery/src/send/writer.rs
+++ b/qrecovery/src/send/writer.rs
@@ -291,28 +291,28 @@ impl<TX> Drop for Writer<TX> {
                 Sender::Ready(s) => {
                     #[cfg(debug_assertions)]
                     tracing::warn!(
-                        target: "quic",
-                        "The sending {} is not closed before dropped!",
+                        target: "dquic",
+                        "sending stream {} is not closed before drop",
                         s.stream_id(),
                     );
                     #[cfg(not(debug_assertions))]
                     tracing::debug!(
-                        target: "quic",
-                        "The sending {} is not closed before dropped!",
+                        target: "dquic",
+                        "sending stream {} is not closed before drop",
                         s.stream_id(),
                     );
                 }
                 Sender::Sending(s) => {
                     #[cfg(debug_assertions)]
                     tracing::warn!(
-                        target: "quic",
-                        "The sending {} is not closed before dropped!",
+                        target: "dquic",
+                        "sending stream {} is not closed before drop",
                         s.stream_id(),
                     );
                     #[cfg(not(debug_assertions))]
                     tracing::debug!(
-                        target: "quic",
-                        "The sending {} is not closed before dropped!",
+                        target: "dquic",
+                        "sending stream {} is not closed before drop",
                         s.stream_id(),
                     );
                 }

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qtraversal/examples/stun_client.rs
+++ b/qtraversal/examples/stun_client.rs
@@ -44,14 +44,14 @@ async fn main() -> Result<()> {
         .outer_addr()
         .await
         .expect("failed to get outer addr");
-    info!("outer addr: {} agent addr {}", outer_addr, stun_server);
+    info!(target: "stun", %outer_addr, agent_addr = %stun_server, "detected outer address");
     // Ok(())
     let nat_type = stun_client.nat_type().await;
     let local_endpoints = std::sync::Arc::new(LocalEndpoints::new());
     let mut subscriber = local_endpoints.subscribe();
     while let Some(event) = subscriber.recv().await {
-        info!("local endpoint event: {:?}", event);
-        info!("nat type: {:?}", nat_type);
+        info!(target: "stun", ?event, "local endpoint event");
+        info!(target: "stun", ?nat_type, "detected NAT type");
     }
     Ok(())
 

--- a/qtraversal/src/addr.rs
+++ b/qtraversal/src/addr.rs
@@ -160,7 +160,7 @@ impl AddressBook {
         source: Source,
     ) -> io::Result<()> {
         match self.remote_endpoint.entry(endpoint) {
-            Entry::Occupied(_) => return Err(io::Error::other("Duplicate remote endpoint")),
+            Entry::Occupied(_) => return Ok(()),
             Entry::Vacant(e) => {
                 e.insert(source);
             }
@@ -328,6 +328,19 @@ mod tests {
             vec![(InterfaceEndpointKey::Agent(agent_addr), agent)]
         );
         assert!(!book.has_local_endpoint(&bind, InterfaceEndpointKey::Agent(agent_addr), agent));
+    }
+
+    #[test]
+    fn duplicate_peer_endpoint_is_idempotent() {
+        let mut book = AddressBook::default();
+        let endpoint = direct_endpoint(10004);
+
+        book.add_peer_endpoint(endpoint, Source::System)
+            .expect("first peer endpoint insert");
+        book.add_peer_endpoint(endpoint, Source::System)
+            .expect("duplicate peer endpoint should be idempotent");
+
+        assert_eq!(book.remote_endpoint().len(), 1);
     }
 
     #[test]

--- a/qtraversal/src/addr.rs
+++ b/qtraversal/src/addr.rs
@@ -84,7 +84,7 @@ impl AddressBook {
             .values()
             .any(|(_local, frame)| *frame.deref() == addr)
         {
-            tracing::debug!(target: "quic", %addr, "Duplicate local address");
+            tracing::debug!(target: "dquic", %addr, "duplicate local address");
             return Err(io::Error::other("Duplicate local address"));
         }
         let frame = AddAddressFrame::new(self.largest_seq_num, addr, tire, nat_type);
@@ -182,7 +182,7 @@ impl AddressBook {
             .find(|(_, (_local, frame))| *frame.deref() == addr)
             .map(|(key, _)| *key)
         else {
-            tracing::debug!(target: "quic", %addr, "No matching local address to remove");
+            tracing::debug!(target: "dquic", %addr, "no matching local address to remove");
             return Err(io::Error::other("No matching local address"));
         };
         self.local.remove(&seq_num).map(|(_local, _frame)| seq_num);
@@ -198,7 +198,7 @@ impl AddressBook {
     pub(crate) fn add_remote_address(&mut self, remote: AddAddressFrame) -> io::Result<()> {
         match self.remote.entry(remote.seq_num()) {
             Entry::Occupied(_) => {
-                tracing::debug!(target: "quic", remote_seq_num = remote.seq_num(), "Duplicate remote address");
+                tracing::debug!(target: "dquic", remote_seq_num = remote.seq_num(), "duplicate remote address");
                 return Err(io::Error::other("Duplicate remote address"));
             }
             Entry::Vacant(entry) => {
@@ -226,7 +226,7 @@ impl AddressBook {
             .collect();
 
         if addrs.is_empty() {
-            tracing::debug!(target: "quic", ?remote, "No matching local address for remote address");
+            tracing::debug!(target: "dquic", ?remote, "no matching local address for remote address");
             return Err(io::Error::other("No matching local address"));
         }
 

--- a/qtraversal/src/addr.rs
+++ b/qtraversal/src/addr.rs
@@ -11,6 +11,7 @@ use qbase::{
 };
 use qinterface::{bind_uri::BindUri, component::local_endpoint::InterfaceEndpointKey};
 use qresolve::Source;
+use smallvec::{SmallVec, smallvec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalEndpointDelta {
@@ -60,6 +61,36 @@ impl IntoIterator for CloseLocalEndpointsDelta {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PeerEndpointSources {
+    One(Source),
+    Many(SmallVec<[Source; 2]>),
+}
+
+impl PeerEndpointSources {
+    fn new(source: Source) -> Self {
+        Self::One(source)
+    }
+
+    fn insert(&mut self, source: Source) {
+        match self {
+            Self::One(current) if *current == source => {}
+            Self::One(current) => {
+                *self = Self::Many(smallvec![current.clone(), source]);
+            }
+            Self::Many(sources) if sources.contains(&source) => {}
+            Self::Many(sources) => sources.push(source),
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Source> {
+        match self {
+            Self::One(source) => std::slice::from_ref(source).iter(),
+            Self::Many(sources) => sources.as_slice().iter(),
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct AddressBook {
     local: HashMap<u32, (BindUri, AddAddressFrame)>,
@@ -67,7 +98,7 @@ pub struct AddressBook {
     local_endpoint: HashMap<BindUri, HashMap<InterfaceEndpointKey, EndpointAddr>>,
     /// Remote endpoints with their DNS [`Source`] so the puncher can enforce
     /// source-specific constraints (e.g. mDNS endpoints are tied to a NIC).
-    remote_endpoint: HashMap<EndpointAddr, Source>,
+    remote_endpoint: HashMap<EndpointAddr, PeerEndpointSources>,
     largest_seq_num: u32,
 }
 
@@ -160,16 +191,23 @@ impl AddressBook {
         source: Source,
     ) -> io::Result<()> {
         match self.remote_endpoint.entry(endpoint) {
-            Entry::Occupied(_) => return Ok(()),
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().insert(source);
+            }
             Entry::Vacant(e) => {
-                e.insert(source);
+                e.insert(PeerEndpointSources::new(source));
             }
         }
         Ok(())
     }
 
-    pub(crate) fn remote_endpoint(&self) -> &HashMap<EndpointAddr, Source> {
-        &self.remote_endpoint
+    pub(crate) fn remote_endpoint(&self) -> impl Iterator<Item = (EndpointAddr, Source)> + '_ {
+        self.remote_endpoint.iter().flat_map(|(endpoint, sources)| {
+            sources
+                .iter()
+                .cloned()
+                .map(move |source| (*endpoint, source))
+        })
     }
 
     pub(crate) fn remove_local_address(
@@ -256,6 +294,9 @@ impl AddressBook {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use qbase::net::Family;
     use qinterface::component::local_endpoint::InterfaceEndpointKey;
 
     use super::*;
@@ -340,7 +381,32 @@ mod tests {
         book.add_peer_endpoint(endpoint, Source::System)
             .expect("duplicate peer endpoint should be idempotent");
 
-        assert_eq!(book.remote_endpoint().len(), 1);
+        assert_eq!(book.remote_endpoint().count(), 1);
+    }
+
+    #[test]
+    fn same_peer_endpoint_keeps_distinct_sources() {
+        let mut book = AddressBook::default();
+        let endpoint = direct_endpoint(10005);
+        let mdns = Source::Mdns {
+            nic: Arc::from("wlan0"),
+            family: Family::V4,
+        };
+
+        book.add_peer_endpoint(endpoint, Source::System)
+            .expect("system peer endpoint insert");
+        book.add_peer_endpoint(endpoint, mdns.clone())
+            .expect("mdns peer endpoint insert");
+        book.add_peer_endpoint(endpoint, mdns.clone())
+            .expect("duplicate mdns peer endpoint should be idempotent");
+
+        let sources = book
+            .remote_endpoint()
+            .filter_map(|(remote_endpoint, source)| (remote_endpoint == endpoint).then_some(source))
+            .collect::<Vec<_>>();
+        assert_eq!(sources.len(), 2);
+        assert!(sources.contains(&Source::System));
+        assert!(sources.contains(&mdns));
     }
 
     #[test]

--- a/qtraversal/src/future.rs
+++ b/qtraversal/src/future.rs
@@ -187,6 +187,7 @@ mod tests {
 
     use futures::future::join_all;
     use tokio::{sync::Notify, time::timeout};
+    use tracing::Instrument as _;
 
     use super::*;
 
@@ -220,6 +221,7 @@ mod tests {
 
                 assert_eq!(*future.get().await, "Hello world");
             }
+            .in_current_span()
         });
 
         write.notified().await;
@@ -247,6 +249,7 @@ mod tests {
                 assert_eq!(*future.get().await, "Hello world");
                 write.notify_one();
             }
+            .in_current_span()
         });
 
         write.notified().await;
@@ -266,6 +269,7 @@ mod tests {
                 let _ = timeout(Duration::from_millis(100), future.get()).await;
                 let _ = future.assign("Hello world");
             }
+            .in_current_span()
         });
 
         let task = tokio::spawn({
@@ -273,6 +277,7 @@ mod tests {
             async move {
                 assert_eq!(*future.get().await, "Hello world");
             }
+            .in_current_span()
         });
 
         join_all([task, timeout_task]).await;
@@ -290,6 +295,7 @@ mod tests {
             async move {
                 assert_eq!(*future.get().await, "New Hello world");
             }
+            .in_current_span()
         });
         future.assign("New Hello world");
         task.await.unwrap();

--- a/qtraversal/src/nat/client.rs
+++ b/qtraversal/src/nat/client.rs
@@ -663,6 +663,7 @@ impl<I: RefIO + 'static> StunClientsInner<I> {
                     tokio::time::sleep_until(deadline).await;
                 }
             }
+            .in_current_span()
         }));
 
         Self {
@@ -910,7 +911,7 @@ pub static VISUALIZE_NAT_DETECTION: AtomicBool = AtomicBool::new(false);
 macro_rules! visualize_nat_detection {
     ($($tt:tt)*) => {{
         if VISUALIZE_NAT_DETECTION.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::info!($($tt)*);
+            tracing::info!(target: "stun", $($tt)*);
         } else {
             tracing::trace!(target: "stun", $($tt)*);
         }
@@ -951,9 +952,9 @@ async fn detect_nat_type<I: RefIO>(
     .await?;
 
     let Some(response) = response else {
-        visualize_nat_detection!("Result: No response after {retry_times} attempts");
+        visualize_nat_detection!("result: no response after {retry_times} attempts");
         visualize_nat_detection!(
-            "Conclusion: The network feature is {:?}, NAT Type is {:?}\n",
+            "conclusion: The network feature is {:?}, NAT Type is {:?}\n",
             NetFeature::Blocked,
             NatType::Blocked
         );
@@ -974,14 +975,14 @@ async fn detect_nat_type<I: RefIO>(
         StunResponseAttribute::ChangedAddress,
         NatDetectionStep::Access,
     )?;
-    visualize_nat_detection!("Result: Received from {stun_agent1}, external addr: {mapped_addr1}");
+    visualize_nat_detection!("result: received from {stun_agent1}, external addr: {mapped_addr1}");
     if mapped_addr1 == local_addr {
         // Public IP
         visualize_nat_detection!(
-            "Conclusion: Address {local_addr} has public IP, Proceeding to filtering behavior test.\n"
+            "conclusion: Address {local_addr} has public IP, Proceeding to filtering behavior test.\n"
         );
         visualize_nat_detection!(
-            "Filtering Test: probing server {stun_agent2}. Request server to respond from a changed IP:port",
+            "filtering test: probing server {stun_agent2}. Request server to respond from a changed IP:port",
         );
         net_features |= NetFeature::Public;
         let request = Request::change_ip_and_port();
@@ -1011,14 +1012,14 @@ async fn detect_nat_type<I: RefIO>(
             visualize_nat_detection!(
                 "Result: received from {source_addr}, external addr: {mapped_addr2}",
             );
-            visualize_nat_detection!("Conclusion: Destination IP independent filtering\n");
+            visualize_nat_detection!("conclusion: Destination IP independent filtering\n");
         } else {
             net_features |= NetFeature::Restricted;
-            visualize_nat_detection!("Result: No response after {retry_times} attempts");
-            visualize_nat_detection!("Conclusion: Filters packets based on destination IP\n");
+            visualize_nat_detection!("result: no response after {retry_times} attempts");
+            visualize_nat_detection!("conclusion: Filters packets based on destination IP\n");
         }
         visualize_nat_detection!(
-            "Filtering Test: probing server {stun_agent2}. Request server to respond from a changed port",
+            "filtering test: probing server {stun_agent2}. Request server to respond from a changed port",
         );
         let request = Request::change_port();
         let response = nat_detection_request(
@@ -1047,11 +1048,11 @@ async fn detect_nat_type<I: RefIO>(
             visualize_nat_detection!(
                 "Result: received from {source_addr}, external addr: {mapped_addr2}",
             );
-            visualize_nat_detection!("Conclusion: Destination port independent filtering\n");
+            visualize_nat_detection!("conclusion: Destination port independent filtering\n");
         } else {
             net_features |= NetFeature::PortRestricted;
-            visualize_nat_detection!("Result: No response after {retry_times} attempts");
-            visualize_nat_detection!("Conclusion: Filters packets based on destination port\n");
+            visualize_nat_detection!("result: no response after {retry_times} attempts");
+            visualize_nat_detection!("conclusion: Filters packets based on destination port\n");
         }
         let nat_type = NatType::from(net_features);
         visualize_nat_detection!(
@@ -1062,7 +1063,7 @@ async fn detect_nat_type<I: RefIO>(
         Ok(nat_type)
     } else {
         // Private IP
-        visualize_nat_detection!("Conclusion: Address {local_addr} has private IP.\n");
+        visualize_nat_detection!("conclusion: Address {local_addr} has private IP.\n");
         visualize_nat_detection!("Mapping Test1: probing server {stun_agent2}");
         let request = Request::default();
         let response = required_nat_detection_request(
@@ -1091,14 +1092,14 @@ async fn detect_nat_type<I: RefIO>(
         if mapped_addr1 != mapped_addr2 {
             net_features |= NetFeature::Symmetric;
             visualize_nat_detection!(
-                "Result: Received from {stun_agent2}, external addr: {mapped_addr2}"
+                "result: received from {stun_agent2}, external addr: {mapped_addr2}"
             );
             visualize_nat_detection!(
-                "Conclusion: The mapped address is different and destination-dependent.\n"
+                "conclusion: The mapped address is different and destination-dependent.\n"
             );
 
             // 判断规律
-            visualize_nat_detection!("Mapping Test2: probing server {stun_agent3}");
+            visualize_nat_detection!("mapping test2: probing server {stun_agent3}");
             let request = Request::default();
             let response = nat_detection_request(
                 ref_iface.clone(),
@@ -1112,9 +1113,9 @@ async fn detect_nat_type<I: RefIO>(
             .await?;
 
             let Some(response) = response else {
-                visualize_nat_detection!("Result: No response after {retry_times} attempts");
+                visualize_nat_detection!("result: no response after {retry_times} attempts");
                 visualize_nat_detection!(
-                    "Conclusion: Unable to determine port mapping behavior due to lack of response from third server.\n"
+                    "conclusion: Unable to determine port mapping behavior due to lack of response from third server.\n"
                 );
                 return Ok(NatType::from(net_features));
             };
@@ -1128,14 +1129,14 @@ async fn detect_nat_type<I: RefIO>(
             let step1 = mapped_addr2.port() as i32 - mapped_addr1.port() as i32;
             let step2 = mapped_addr3.port() as i32 - mapped_addr2.port() as i32;
             visualize_nat_detection!(
-                "Result: Received from {stun_agent3}, external addr: {mapped_addr3}"
+                "result: received from {stun_agent3}, external addr: {mapped_addr3}"
             );
             if step1 == step2 {
                 visualize_nat_detection!(
-                    "Conclusion: The port changes regularly with step {step1}\n"
+                    "conclusion: The port changes regularly with step {step1}\n"
                 );
             } else {
-                visualize_nat_detection!("Conclusion: The Ports change randomly.\n");
+                visualize_nat_detection!("conclusion: The Ports change randomly.\n");
             }
             Ok(NatType::from(net_features))
         } else {
@@ -1149,7 +1150,7 @@ async fn detect_nat_type<I: RefIO>(
             // server5: ip2:port1
             // server6: ip3:port2
             visualize_nat_detection!(
-                "Filtering Test: probing server {stun_agent2}. Request server to respond from a changed IP and port",
+                "filtering test: probing server {stun_agent2}. Request server to respond from a changed IP and port",
             );
             let request = Request::change_ip_and_port();
             // 可能会不响应，超时太久会导致探测很久
@@ -1179,16 +1180,16 @@ async fn detect_nat_type<I: RefIO>(
                 visualize_nat_detection!(
                     "Result: received from {source_addr}, external addr: {mapped_addr2}",
                 );
-                visualize_nat_detection!("Conclusion: Destination IP independent filtering\n");
+                visualize_nat_detection!("conclusion: Destination IP independent filtering\n");
             } else {
                 net_features |= NetFeature::Restricted;
                 visualize_nat_detection!(
-                    "Result: No response after {RESTRICTED_RETRY_TIMES} attempts"
+                    "result: no response after {RESTRICTED_RETRY_TIMES} attempts"
                 );
-                visualize_nat_detection!("Conclusion: Filters packets based on destination IP\n");
+                visualize_nat_detection!("conclusion: Filters packets based on destination IP\n");
             }
             visualize_nat_detection!(
-                "Filtering Test: probing server {stun_agent2}. Request server to respond from a changed port",
+                "filtering test: probing server {stun_agent2}. Request server to respond from a changed port",
             );
             // Restricted test
             // server2 换 port 即 server5 回，可能不响应
@@ -1220,13 +1221,13 @@ async fn detect_nat_type<I: RefIO>(
                 visualize_nat_detection!(
                     "Result: received from {source_addr}, external addr: {mapped_addr2}",
                 );
-                visualize_nat_detection!("Conclusion: Destination port independent filtering\n");
+                visualize_nat_detection!("conclusion: Destination port independent filtering\n");
             } else {
                 net_features |= NetFeature::PortRestricted;
                 visualize_nat_detection!(
-                    "Result: No response after {RESTRICTED_RETRY_TIMES} attempts"
+                    "result: no response after {RESTRICTED_RETRY_TIMES} attempts"
                 );
-                visualize_nat_detection!("Conclusion: Filters packets based on destination port\n");
+                visualize_nat_detection!("conclusion: Filters packets based on destination port\n");
             }
             // dynamic test， 请求 server3
             visualize_nat_detection!("Dynamic Test: probing server {stun_agent3}",);
@@ -1262,19 +1263,19 @@ async fn detect_nat_type<I: RefIO>(
                 if mapped_addr1 != mapped_addr3 {
                     net_features |= NetFeature::Dynamic;
                     visualize_nat_detection!(
-                        "Conclusion: Mapping inconsistency indicates Address-Dependent Mapping, a Dynamic NAT type\n"
+                        "conclusion: Mapping inconsistency indicates Address-Dependent Mapping, a Dynamic NAT type\n"
                     );
                 } else {
                     visualize_nat_detection!(
-                        "Conclusion: The mapping address is consistent, not Dynamic\n"
+                        "conclusion: The mapping address is consistent, not Dynamic\n"
                     );
                 }
             } else {
                 // 不回包也视为动态型
                 net_features |= NetFeature::Dynamic;
-                visualize_nat_detection!("Result: No response after 3 attempts");
+                visualize_nat_detection!("result: no response after 3 attempts");
                 visualize_nat_detection!(
-                    "Conclusion: Absence of server response may indicates Dynamic NAT behavior\n"
+                    "conclusion: Absence of server response may indicates Dynamic NAT behavior\n"
                 );
             }
             let nat_type = NatType::from(net_features);

--- a/qtraversal/src/nat/server.rs
+++ b/qtraversal/src/nat/server.rs
@@ -8,7 +8,7 @@ use std::{
 
 use qinterface::{Interface, WeakInterface, component::Component, io::RefIO};
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{info, trace};
+use tracing::{Instrument as _, info, trace};
 
 use super::{
     msg::{Attr, Request, Response},
@@ -61,9 +61,10 @@ impl<I: RefIO + 'static> StunServer<I> {
     }
 
     pub fn spawn(self) -> AbortOnDropHandle<io::Result<()>> {
-        AbortOnDropHandle::new(tokio::spawn(async move {
-            serve_loop(self.ref_iface, self.stun_router, self.config).await
-        }))
+        AbortOnDropHandle::new(tokio::spawn(
+            async move { serve_loop(self.ref_iface, self.stun_router, self.config).await }
+                .in_current_span(),
+        ))
     }
 }
 
@@ -72,7 +73,7 @@ async fn serve_loop<I: RefIO>(
     stun_router: StunRouter,
     config: StunServerConfig,
 ) -> io::Result<()> {
-    info!(target: "stun", "Server started");
+    info!(target: "stun", "server started");
     let local_addr = ref_iface.iface().local_addr()?;
 
     while let Some((request, txid, src)) = stun_router.receive_request().await {
@@ -126,7 +127,7 @@ async fn serve_loop<I: RefIO>(
         }
     }
 
-    trace!(target: "stun", "Request handler finished - no more requests");
+    trace!(target: "stun", "request handler finished with no more requests");
     Ok(())
 }
 

--- a/qtraversal/src/punch/predictor.rs
+++ b/qtraversal/src/punch/predictor.rs
@@ -16,6 +16,7 @@ use qinterface::{
     io::{IO, ProductIO},
     manager::InterfaceManager,
 };
+use tracing::Instrument as _;
 
 use crate::{
     punch::{
@@ -153,7 +154,7 @@ impl PortPredictor {
             bind_uri = %bind_uri,
             dst = %dst,
             device = %device,
-            "Created port predictor"
+            "created port predictor"
         );
         Ok(Self {
             ifaces,
@@ -452,9 +453,12 @@ impl Drop for PortPredictor {
             .map(|bind_uri| self.ifaces.unbind(bind_uri))
             .collect();
         if !futures.is_empty() {
-            tokio::spawn(async move {
-                futures::future::join_all(futures).await;
-            });
+            tokio::spawn(
+                async move {
+                    futures::future::join_all(futures).await;
+                }
+                .in_current_span(),
+            );
         }
     }
 }

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -804,11 +804,7 @@ where
         let (delta, remote_endpoints) = {
             let mut address_book = self.0.address_book.lock().unwrap();
             let delta = address_book.upsert_local_endpoint(bind.clone(), key, endpoint);
-            let remote_endpoints = address_book
-                .remote_endpoint()
-                .iter()
-                .map(|(endpoint, source)| (*endpoint, source.clone()))
-                .collect();
+            let remote_endpoints = address_book.remote_endpoint().collect();
             (delta, remote_endpoints)
         };
 

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -895,12 +895,12 @@ where
 
         let punch_id = (&local, &add_address_frame).punch_id();
         if self.0.punch_history.contains_key(&punch_id) {
-            tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", Some(local.nat_type()), Some(add_address_frame.nat_type())), "punch already completed, skipping");
+            tracing::debug!(target: "punch", %punch_id, local_nat = ?local.nat_type(), remote_nat = ?add_address_frame.nat_type(), "punch already completed, skipping");
             return Ok(());
         }
         match self.0.transaction.entry(punch_id) {
             Entry::Occupied(_) => {
-                tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", Some(local.nat_type()), Some(add_address_frame.nat_type())), "dup transaction for punch");
+                tracing::debug!(target: "punch", %punch_id, local_nat = ?local.nat_type(), remote_nat = ?add_address_frame.nat_type(), "dup transaction for punch");
                 return Ok(());
             }
             Entry::Vacant(entry) => {
@@ -950,7 +950,7 @@ where
                     .ok_or_else(|| {
                         io::Error::new(io::ErrorKind::NotFound, "local address not matched")
                     })?;
-                tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", Some(local_address.nat_type()), Some(punch_me_now_frame.nat_type())), "received punch me now frame, start passive punch");
+                tracing::debug!(target: "punch", %punch_id, local_nat = ?local_address.nat_type(), remote_nat = ?punch_me_now_frame.nat_type(), "received punch me now frame, start passive punch");
                 async move {
                     let result = puncher
                         .punch_passively(bind, &local_address, &punch_me_now_frame, tx)
@@ -1004,7 +1004,7 @@ where
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         let link = Link::new(bind_addr, *remote.deref());
         let punch_id = (local, remote).punch_id();
-        tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "starting active punch");
+        tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "starting active punch");
 
         let mut punch_me_now = PunchMeNowFrame::new(
             local.seq_num(),
@@ -1066,13 +1066,13 @@ where
             // 1: Remote is FullCone
             // Send direct Hello to remote, expecting Hello(Done).
             (_, FullCone) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Remote FullCone, sending direct Hello");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Remote FullCone, sending direct Hello");
                 let iface = ifaces
                     .borrow(&bind_uri)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
                 let time = Duration::from_millis(100);
                 for i in 0..5 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending Hello expecting Hello(Done) or receiving Hello");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending Hello expecting Hello(Done) or receiving Hello");
                     self.0
                         .send_packet(
                             &iface,
@@ -1091,23 +1091,23 @@ where
                             // continue loop
                         }
                         Ok((_, punch_hello)) = async { Ok::<_, io::Error>(tx.wait_punch_hello().await) } => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "received Hello, sending broker PunchDone confirmation");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "received Hello, sending broker PunchDone confirmation");
                             broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(&punch_hello))]);
                             return Ok(());
                         }
                         _ = tx.wait_punch_done() => {
-                            tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch success");
+                            tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch success");
                             return Ok(());
                         }
                     }
                 }
-                tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch failed");
+                tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch failed");
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "punch timeout"));
             }
             // 2. Local Dynamic, Remote Symmetric -> New Interface & Birthday Attack
             // Send PunchMeNow, expect PunchMeNow. After receiving, start collision, expect Hello(Done).
             (Dynamic, Symmetric) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Local Dynamic, Remote Symmetric, new interface & birthday attack");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Local Dynamic, Remote Symmetric, new interface & birthday attack");
                 // TODO: Creating a new iface is not strictly necessary; could reuse an available temporary address.
                 let (iface, stun_client) = dynamic_iface(&bind_uri).await?;
 
@@ -1115,7 +1115,7 @@ where
                 punch_ifaces.insert(bind_uri.clone(), iface.clone());
                 let outer_addr = stun_client.outer_addr().await?;
                 punch_me_now.set_addr(outer_addr);
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow expecting PunchMeNow then collision");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow expecting PunchMeNow then collision");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
 
                 let link = Link::new(iface.bound_addr()?, link.dst);
@@ -1129,7 +1129,7 @@ where
                             self.0.collision(&iface, link, punch_id, KNOCK_TTL).await?;
                         }
                         Ok((link, punch_hello)) = async { Ok::<_, io::Error>(tx.wait_punch_hello().await) } => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "received Hello, sending broker PunchDone confirmation");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "received Hello, sending broker PunchDone confirmation");
                             broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(&punch_hello))]);
                             break Ok(());
                         }
@@ -1148,7 +1148,7 @@ where
             // Send PunchMeNow, expect PunchMeNow. Use random socket collision, expect Hello(Done).
             (Symmetric, RestrictedPort) => {
                 // Send PunchMeNow first
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow expecting PunchMeNow then rush");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow expecting PunchMeNow then rush");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
 
                 if timeout(COLLISION_TIMEOUT, tx.wait_punch_me_now())
@@ -1171,21 +1171,21 @@ where
                         Box::pin(async move { puncher.send_packet(iface, link, ttl, frame).await })
                     });
 
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "starting consolidated birthday attack");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "starting consolidated birthday attack");
                     match predictor
                         .predict(punch_id, tx.clone(), packet_send_fn)
                         .await
                     {
                         Ok(Some((bind_uri, iface))) => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %bind_uri, "birthday attack succeeded");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %bind_uri, "birthday attack succeeded");
                             self.0.punch_ifaces.insert(bind_uri.clone(), iface);
                             return Ok(());
                         }
                         Ok(None) => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "birthday attack completed without success");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "birthday attack completed without success");
                         }
                         Err(e) => {
-                            tracing::warn!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %e, "birthday attack failed");
+                            tracing::warn!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %e, "birthday attack failed");
                         }
                     }
                 }
@@ -1195,21 +1195,21 @@ where
             // 4. Local Symmetric, Remote RestrictedCone -> Reverse Punching
             // Send PunchMeNow, expect remote to open hole and respond PunchMeNow. Then send direct Hello, expect Hello(Done).
             (Symmetric, RestrictedCone) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Local Symmetric, Remote RestrictedCone, reverse punching");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Local Symmetric, Remote RestrictedCone, reverse punching");
                 tracing::trace!(target: "punch", %punch_id, "sending PunchMeNow expecting PunchMeNow then Hello");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
                 if timeout(PUNCH_ME_NOW_TIMEOUT, tx.wait_punch_me_now())
                     .await
                     .is_err()
                 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "wait for PunchMeNow timeout, try to connect blindly");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "wait for PunchMeNow timeout, try to connect blindly");
                 }
 
                 let iface = ifaces
                     .borrow(&bind_uri)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
                 for i in 0..5 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending Hello expecting Hello(Done)");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending Hello expecting Hello(Done)");
                     self.0
                         .send_packet(
                             &iface,
@@ -1223,18 +1223,18 @@ where
                         )
                         .await?;
                     if (timeout(KNOCK_TIMEOUT * (1 << i), tx.wait_punch_done()).await).is_ok() {
-                        tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch success");
+                        tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch success");
                         return Ok(());
                     }
                 }
 
-                tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch failed");
+                tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch failed");
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "punch timeout"));
             }
             // 5. Local Dynamic
             // New Interface, detect external address. Then send PunchMeNow and Hello, expect Hello(Done).
             (Dynamic, _) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Local Dynamic, new interface & send PunchMeNow + Hello");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Local Dynamic, new interface & send PunchMeNow + Hello");
                 // Use new iface, update PunchMeNow address.
                 // TODO: Creating a new iface is not strictly necessary; could reuse an available temporary address.
                 let (iface, stun_client) = dynamic_iface(&bind_uri).await?;
@@ -1247,7 +1247,7 @@ where
                 let link = Link::new(iface.bound_addr()?, link.dst);
                 let time = Duration::from_millis(100);
                 for i in 0..MAX_RETRIES {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending Hello expecting Hello(Done)");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending Hello expecting Hello(Done)");
                     self.0
                         .send_packet(
                             &iface,
@@ -1266,12 +1266,12 @@ where
                             // continue loop
                         }
                         Ok((_, punch_hello)) = async { Ok::<_, io::Error>(tx.wait_punch_hello().await) } => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "received Hello, sending broker PunchDone confirmation");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "received Hello, sending broker PunchDone confirmation");
                             broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(&punch_hello))]);
                             return Ok(());
                         }
                         _ = tx.wait_punch_done() => {
-                            tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch success");
+                            tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch success");
                             return Ok(());
                         }
                     }
@@ -1286,13 +1286,13 @@ where
             (FullCone | RestrictedCone, Symmetric)
             | (FullCone | RestrictedCone | RestrictedPort, Dynamic)
             | (_, RestrictedCone | RestrictedPort) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: General punching, send Hello with TTL & PunchMeNow");
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow + Hello expecting Hello then Hello(Done)");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: General punching, send Hello with TTL & PunchMeNow");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow + Hello expecting Hello then Hello(Done)");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
                 let iface = ifaces
                     .borrow(&bind_uri)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending Hello expecting Hello");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending Hello expecting Hello");
                 self.0
                     .send_packet(
                         &iface,
@@ -1306,34 +1306,34 @@ where
                     )
                     .await?;
                 if let Ok((_, punch_hello)) = timeout(PUNCH_TIMEOUT, tx.wait_punch_hello()).await {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending broker PunchDone confirmation");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending broker PunchDone confirmation");
                     broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(
                         &punch_hello,
                     ))]);
-                    tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "actively punch success");
+                    tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "actively punch success");
                     return Ok(());
                 }
-                tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch failed");
+                tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch failed");
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "punch timeout"));
             }
             // 7. Local RestrictedPort, Remote Symmetric -> Birthday Attack (Hold Hole)
             // Send packets to 300 random ports, then notify with PunchMeNow. Expect Hello, then respond Hello(Done).
             (RestrictedPort, Symmetric) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Local RestrictedPort, Remote Symmetric, birthday attack hold hole");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Local RestrictedPort, Remote Symmetric, birthday attack hold hole");
                 let iface = ifaces
                     .borrow(&bind_uri)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
                 self.0.collision(&iface, link, punch_id, KNOCK_TTL).await?;
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow expecting Hello then Hello(Done)");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow expecting Hello then Hello(Done)");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
                 if let Ok((link, punch_hello)) =
                     timeout(BIRTHDAY_TIMEOUT, tx.wait_punch_hello()).await
                 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending broker PunchDone confirmation");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending broker PunchDone confirmation");
                     broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(
                         &punch_hello,
                     ))]);
-                    tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "punch success with collision");
+                    tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "punch success with collision");
                     return Ok(());
                 }
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "punch timeout"));
@@ -1342,7 +1342,7 @@ where
             // Hold holes on 30 random ports, send PunchMeNow. Expect Collision, then respond PunchMeNow.
             // Repeat until 300 sockets used.
             (Symmetric, Dynamic) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "strategy: Local Symmetric, Remote Dynamic, hold holes & send PunchMeNow");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "strategy: Local Symmetric, Remote Dynamic, hold holes & send PunchMeNow");
 
                 // Use new consolidated PortPredictor birthday attack
                 let mut predictor = PortPredictor::new(
@@ -1360,24 +1360,24 @@ where
                 });
 
                 // Send initial PunchMeNow to notify peer
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending initial PunchMeNow for Dynamic strategy");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending initial PunchMeNow for Dynamic strategy");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
 
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "starting consolidated birthday attack for Dynamic strategy");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "starting consolidated birthday attack for Dynamic strategy");
                 match predictor
                     .predict(punch_id, tx.clone(), packet_send_fn)
                     .await
                 {
                     Ok(Some((bind_uri, iface))) => {
-                        tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %bind_uri, "birthday attack succeeded for Dynamic strategy");
+                        tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %bind_uri, "birthday attack succeeded for Dynamic strategy");
                         self.0.punch_ifaces.insert(bind_uri.clone(), iface);
                         return Ok(());
                     }
                     Ok(None) => {
-                        tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "birthday attack completed without success for Dynamic strategy");
+                        tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "birthday attack completed without success for Dynamic strategy");
                     }
                     Err(e) => {
-                        tracing::warn!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %e, "birthday attack failed for Dynamic strategy");
+                        tracing::warn!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %e, "birthday attack failed for Dynamic strategy");
                     }
                 }
                 return Err(io::Error::new(io::ErrorKind::TimedOut, "punch timeout"));
@@ -1397,7 +1397,7 @@ where
         let remote_nat = remote_address.nat_type();
         let local_nat = local_address.nat_type();
         let punch_id = PunchId::new(local_address.seq_num(), remote_address.local_seq());
-        tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "starting passive punch");
+        tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "starting passive punch");
         let socket_addr = SocketAddr::try_from(bind.clone())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         if local_nat == Blocked
@@ -1428,7 +1428,7 @@ where
             // 1. Local Dynamic, Remote Symmetric
             // Remote has opened hole. We use new interface to collide, expecting Hello(Done).
             (Dynamic, Symmetric) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "passive strategy: Local Dynamic, Remote Symmetric, use new interface to collide");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "passive strategy: Local Dynamic, Remote Symmetric, use new interface to collide");
                 let iface = ifaces
                     .borrow(&bind)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
@@ -1442,7 +1442,7 @@ where
                             self.0.collision(&iface, link, punch_id, KNOCK_TTL).await?;
                         }
                         Ok((link, punch_hello)) = async { Ok::<_, io::Error>(tx.wait_punch_hello().await) } => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "received Hello, sending broker PunchDone confirmation");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "received Hello, sending broker PunchDone confirmation");
                             broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(&punch_hello))]);
                             return Ok(());
                         }
@@ -1454,7 +1454,7 @@ where
             // 2. Local RestrictedPort, Remote Symmetric
             // We open holes on 300 random ports, send PunchMeNow. Expect Hello collision, then respond Hello(Done).
             (RestrictedPort, Symmetric) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "passive strategy: Local RestrictedPort, Remote Symmetric, open holes & send PunchMeNow");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "passive strategy: Local RestrictedPort, Remote Symmetric, open holes & send PunchMeNow");
                 let iface = ifaces
                     .borrow(&bind)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
@@ -1466,12 +1466,12 @@ where
                     local_address.tire(),
                     local_nat,
                 );
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow expecting Hello then Hello(Done)");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow expecting Hello then Hello(Done)");
                 broker.send_frame([ReliableFrame::PunchMeNow(punch_me_now)]);
                 if let Ok((link, punch_hello)) =
                     tokio::time::timeout(BIRTHDAY_TIMEOUT, tx.wait_punch_hello()).await
                 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending broker PunchDone confirmation");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending broker PunchDone confirmation");
                     broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(
                         &punch_hello,
                     ))]);
@@ -1496,28 +1496,28 @@ where
                     Box::pin(async move { puncher.send_packet(iface, link, ttl, frame).await })
                 });
 
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "starting consolidated birthday attack");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "starting consolidated birthday attack");
                 match predictor
                     .predict(punch_id, tx.clone(), packet_send_fn)
                     .await
                 {
                     Ok(Some((bind_uri, iface))) => {
-                        tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %bind_uri, "birthday attack succeeded");
+                        tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %bind_uri, "birthday attack succeeded");
                         self.0.punch_ifaces.insert(bind_uri.clone(), iface);
                         return Ok(());
                     }
                     Ok(None) => {
-                        tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "birthday attack completed without success");
+                        tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "birthday attack completed without success");
                     }
                     Err(e) => {
-                        tracing::warn!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %e, "birthday attack failed");
+                        tracing::warn!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %e, "birthday attack failed");
                     }
                 }
             }
             // 4. Local RestrictedCone, Remote Symmetric
             // Reflect, Hello and  PunchmeNow, wait for hello, send Hello(Done)
             (RestrictedCone, Symmetric) => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "passive strategy: Local RestrictedCone, Remote Symmetric, reflect & send PunchMeNow");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "passive strategy: Local RestrictedCone, Remote Symmetric, reflect & send PunchMeNow");
                 let iface = ifaces
                     .borrow(&bind)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
@@ -1528,7 +1528,7 @@ where
                     local_address.tire(),
                     local_nat,
                 );
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "sending PunchMeNow expecting Hello then Hello(Done)");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "sending PunchMeNow expecting Hello then Hello(Done)");
                 let punch_hello_frame =
                     PunchHelloFrame::new(punch_id.local_seq, punch_id.remote_seq, DEFAULT_PROBE_ID);
                 self.0
@@ -1538,7 +1538,7 @@ where
                 if let Ok((link, punch_hello)) =
                     tokio::time::timeout(PUNCH_TIMEOUT, tx.wait_punch_hello()).await
                 {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending broker PunchDone confirmation");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending broker PunchDone confirmation");
                     broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(
                         &punch_hello,
                     ))]);
@@ -1548,13 +1548,13 @@ where
             // 5. General Punching
             // Received PunchMeNow implies remote has opened hole. We send direct Hello, expecting Hello(Done).
             _ => {
-                tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "passive strategy: General punching, send direct Hello");
+                tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "passive strategy: General punching, send direct Hello");
                 let iface = ifaces
                     .borrow(&bind)
                     .ok_or_else(|| io::Error::other("No interface found"))?;
                 let time = Duration::from_millis(100);
                 for i in 0..MAX_RETRIES {
-                    tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), %link, "sending Hello expecting Hello(Done)");
+                    tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, %link, "sending Hello expecting Hello(Done)");
                     self.0
                         .send_packet(
                             &iface,
@@ -1573,12 +1573,12 @@ where
                             // continue loop
                         }
                         Ok((_, punch_hello)) = async { Ok::<_, io::Error>(tx.wait_punch_hello().await) } => {
-                            tracing::trace!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "received Hello, sending broker PunchDone confirmation");
+                            tracing::trace!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "received Hello, sending broker PunchDone confirmation");
                             broker.send_frame([ReliableFrame::PunchDone(PunchDoneFrame::respond_to(&punch_hello))]);
                             return Ok(());
                         }
                         _ = tx.wait_punch_done() => {
-                            tracing::debug!(target: "punch", %punch_id, nat_pair = %format!("{:?}->{:?}", local_nat, remote_nat), "passively punch success");
+                            tracing::debug!(target: "punch", %punch_id, local_nat = ?local_nat, remote_nat = ?remote_nat, "passively punch success");
                             return Ok(());
                         }
                     }

--- a/qtraversal/src/route.rs
+++ b/qtraversal/src/route.rs
@@ -28,6 +28,7 @@ use qinterface::{
 };
 use smallvec::SmallVec;
 use tokio_util::task::AbortOnDropHandle;
+use tracing::Instrument as _;
 
 pub type ArcRecvQueue = ArcAsyncDeque<(BytesMut, PathWay, Link)>;
 
@@ -181,9 +182,10 @@ impl ReceiveAndDeliverPacketComponent {
         forwarder: Option<Forwarder<I>>,
         iface_ref: I,
     ) -> AbortOnDropHandle<io::Result<()>> {
-        AbortOnDropHandle::new(tokio::spawn(async move {
-            let iface = iface_ref.iface();
-            let bind_uri = iface.bind_uri();
+        AbortOnDropHandle::new(tokio::spawn(
+            async move {
+                let iface = iface_ref.iface();
+                let bind_uri = iface.bind_uri();
 
             let deliver_quic_packet = async |pkt: BytesMut, route: Route| {
                 let Some(quic_router) = quic_router.as_ref() else {
@@ -241,24 +243,26 @@ impl ReceiveAndDeliverPacketComponent {
                 };
 
             let (mut bufs, mut hdrs) = (vec![], vec![]);
-            loop {
-                use crate::packet::{Header, be_header};
-                for (pkt, hdr) in iface.recvmmsg(&mut bufs, &mut hdrs).await? {
-                    match be_header(&pkt) {
-                        // quic
-                        Err(_) => deliver_quic_packet(pkt, hdr).await,
-                        // stun
-                        Ok((_remain, Header::Stun(_stun_header))) => {
-                            deliver_stun_packet(pkt, hdr).await
-                        }
-                        // forward
-                        Ok((_remain, Header::Forward(forward_header))) => {
-                            deliver_forward_packet(pkt, hdr, forward_header).await?
+                loop {
+                    use crate::packet::{Header, be_header};
+                    for (pkt, hdr) in iface.recvmmsg(&mut bufs, &mut hdrs).await? {
+                        match be_header(&pkt) {
+                            // quic
+                            Err(_) => deliver_quic_packet(pkt, hdr).await,
+                            // stun
+                            Ok((_remain, Header::Stun(_stun_header))) => {
+                                deliver_stun_packet(pkt, hdr).await
+                            }
+                            // forward
+                            Ok((_remain, Header::Forward(forward_header))) => {
+                                deliver_forward_packet(pkt, hdr, forward_header).await?
+                            }
                         }
                     }
                 }
             }
-        }))
+            .in_current_span(),
+        ))
     }
 }
 

--- a/qtraversal/tests/detect.rs
+++ b/qtraversal/tests/detect.rs
@@ -135,12 +135,19 @@ async fn test_detect_case(case: usize) {
         .outer_addr()
         .await
         .expect("failed to get outer addr");
-    tracing::info!("outer addr: {} agent addr {}", outer_addr, stun_agent);
+    tracing::info!(target: "stun", %outer_addr, agent_addr = %stun_agent, "detected outer address");
     let nat_type = stun_client
         .nat_type()
         .await
         .expect("failed to get nat type");
-    tracing::info!(case.bind_addr, case.outer_addr, ?nat_type, ?case.nat_type);
+    tracing::info!(
+        target: "stun",
+        bind_addr = %case.bind_addr,
+        outer_addr = %case.outer_addr,
+        ?nat_type,
+        expected_nat_type = ?case.nat_type,
+        "NAT detection case result"
+    );
     assert!(nat_type == case.nat_type);
 }
 

--- a/qudp/examples/receive.rs
+++ b/qudp/examples/receive.rs
@@ -23,15 +23,16 @@ async fn main() {
         match receiver.recv().await {
             Ok(n) => {
                 tracing::info!(
-                    "Received {} packets, dst {}, src {} len {}",
-                    n,
-                    receiver.lines[0].dst,
-                    receiver.lines[0].src,
-                    receiver.lines[0].seg_size
+                    target: "qudp",
+                    packets = n,
+                    dst = %receiver.lines[0].dst,
+                    src = %receiver.lines[0].src,
+                    len = receiver.lines[0].seg_size,
+                    "received packets"
                 );
             }
             Err(e) => {
-                tracing::error!("Receive failed: {}", e);
+                tracing::error!(target: "qudp", error = %e, "receive failed");
             }
         }
     }

--- a/qudp/examples/send.rs
+++ b/qudp/examples/send.rs
@@ -42,7 +42,9 @@ async fn main() {
     let payloads = vec![IoSlice::new(&payload[..]); args.msg_count];
 
     match socket.send(&payloads, send_hdr).await {
-        Ok(n) => tracing::info!("Sent {} packets, bytes: {}", n, n * args.msg_size),
-        Err(e) => tracing::error!("Send failed: {}", e),
+        Ok(n) => {
+            tracing::info!(target: "qudp", packets = n, bytes = n * args.msg_size, "sent packets")
+        }
+        Err(e) => tracing::error!(target: "qudp", error = %e, "send failed"),
     }
 }

--- a/qudp/src/windows.rs
+++ b/qudp/src/windows.rs
@@ -50,7 +50,7 @@ impl Io for UdpSocket {
             }
         }
         if let Err(e) = socket.bind(&addr.into()) {
-            tracing::error!(target: "qudp", "Failed to bind socket: {}", e);
+            tracing::error!(target: "qudp", error = %e, "failed to bind socket");
             return Err(io::Error::new(io::ErrorKind::AddrInUse, e));
         }
         Ok(())
@@ -401,8 +401,8 @@ fn wsarecvmsg_ptr() -> &'static WinSock::LPFN_WSARECVMSG {
         if s == WinSock::INVALID_SOCKET {
             tracing::warn!(
                 target: "qudp",
-                "Failed to create socket for WSARecvMsg function pointer: {}",
-                io::Error::last_os_error()
+                error = %io::Error::last_os_error(),
+                "failed to create socket for WSARecvMsg function pointer"
             );
             return None;
         }
@@ -430,15 +430,15 @@ fn wsarecvmsg_ptr() -> &'static WinSock::LPFN_WSARECVMSG {
         if ret == -1 {
             tracing::warn!(
                 target: "qudp",
-                "Failed to get WSARecvMsg function pointer: {}",
-                io::Error::last_os_error()
+                error = %io::Error::last_os_error(),
+                "failed to get WSARecvMsg function pointer"
             );
         } else if len as usize != mem::size_of::<WinSock::LPFN_WSARECVMSG>() {
             tracing::warn!(
                 target: "qudp",
-                "WSARecvMsg function pointer size mismatch: expected {}, got {}",
-                mem::size_of::<WinSock::LPFN_WSARECVMSG>(),
-                len
+                expected = mem::size_of::<WinSock::LPFN_WSARECVMSG>(),
+                len,
+                "WSARecvMsg function pointer size mismatch"
             );
             wsa_recvmsg_ptr = None;
         }


### PR DESCRIPTION
## Release prep

Prepare the dquic v0.7.0-beta.2 release wave.

### Versions

- `qtraversal` v0.7.0-beta.2
- `dquic` v0.7.0-beta.2
- unchanged members stay on their existing published versions; `h3-shim` remains outside the release surface

### Changes

- Preserve distinct DNS resolver sources for the same peer endpoint address in `qtraversal`, so source-specific NAT traversal constraints such as mDNS NIC affinity remain available.
- Keep duplicate peer endpoint insertion idempotent.
- Standardize dquic tracing/logging.
- Mark prerelease tags as GitHub prereleases in release automation.

### Draft tag message

```markdown
# dquic v0.7.0-beta.2

## Changes

- Preserve distinct DNS resolver sources for the same peer endpoint address in `qtraversal`, so source-specific NAT traversal constraints such as mDNS NIC affinity remain available.
- Keep duplicate peer endpoint insertion idempotent.
- Standardize dquic tracing/logging.
- Mark prerelease tags as GitHub prereleases in release automation.

## Published crates

- `qtraversal` v0.7.0-beta.2
- `dquic` v0.7.0-beta.2

Unchanged workspace crates remain on their existing published versions. `h3-shim` remains outside the dquic release surface.
```

### Verification

- `cargo +nightly fmt --all -- --check`
- `cargo test -p qtraversal peer_endpoint -- --nocapture`
- `cargo +1.91.1 semver-checks --manifest-path qtraversal/Cargo.toml --baseline-version 0.7.0-beta.1 --release-type patch`
- `cargo +1.91.1 semver-checks --manifest-path dquic/Cargo.toml --baseline-version 0.7.0-beta.1 --release-type patch`

`cargo publish --dry-run --locked -p qtraversal -p dquic` packaged and verified `qtraversal`, then was interrupted during `dquic` verification after repeated crates.io network timeouts. PR CI should rerun the full publish dry-run.

### Release gates

- Target branch: `main`
- Planned tag: `v0.7.0-beta.2`
- Surface: crates.io + tag-CI GitHub Release
- Initial/incremental: incremental
