### PR TITLE
feat: make netwatcher optional

### DIFF
--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -44,6 +44,7 @@ tracing-appender = { workspace = true }
 default = ["datagram"]
 telemetry = ["qconnection/telemetry"]
 datagram = ["qconnection/datagram"]
+netwatcher = ["qconnection/netwatcher"]
 
 [dev-dependencies.tracing-subscriber]
 workspace = true

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -47,6 +47,7 @@ qdatagram = { workspace = true, optional = true }
 [features]
 default = ["datagram"]
 datagram = ["dep:qdatagram"]
+netwatcher = ["qinterface/netwatcher"]
 telemetry = ["qevent/telemetry"]
 
 [dev-dependencies]

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -16,7 +16,7 @@ derive_more = { workspace = true, features = ["deref"] }
 futures = { workspace = true }
 http = { workspace = true }
 netdev = { workspace = true }
-netwatcher = { workspace = true }
+netwatcher = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 qbase = { workspace = true }
 qevent = { workspace = true }
@@ -37,4 +37,5 @@ tokio = { workspace = true, features = [
 ] }
 
 [features]
+netwatcher = ["dep:netwatcher"]
 qudp = ["dep:qudp"]

--- a/qinterface/src/device.rs
+++ b/qinterface/src/device.rs
@@ -1,14 +1,18 @@
+#[cfg(feature = "netwatcher")]
+use std::sync::Mutex;
 use std::{
     collections::HashMap,
     fmt::Debug,
     net::IpAddr,
-    sync::{Arc, Mutex, OnceLock, RwLock},
+    sync::{Arc, OnceLock, RwLock},
     time::Duration,
 };
 
 use derive_more::{Deref, DerefMut};
 pub use netdev::Interface;
+#[cfg(feature = "netwatcher")]
 pub use netwatcher::Error as WatcherError;
+#[cfg(feature = "netwatcher")]
 use netwatcher::WatchHandle;
 use qbase::{
     net::Family,
@@ -321,6 +325,7 @@ impl State {
 
 pub struct Devices {
     state: Arc<State>,
+    #[cfg(feature = "netwatcher")]
     watcher: Mutex<Result<WatchHandle, WatcherError>>,
     _timer: AbortOnDropHandle<()>,
 }
@@ -329,7 +334,6 @@ impl Debug for Devices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Devices")
             .field("state", &self.state)
-            .field("watcher", &"...")
             .field("_timer", &self._timer)
             .finish()
     }
@@ -357,6 +361,7 @@ impl Devices {
             .in_current_span()
         }));
 
+        #[cfg(feature = "netwatcher")]
         let watcher = netwatcher::watch_interfaces_with_callback({
             let state = state.clone();
             move |_update| {
@@ -365,6 +370,7 @@ impl Devices {
             }
         });
 
+        #[cfg(feature = "netwatcher")]
         if let Err(initial_watcher_error) = &watcher {
             tracing::warn!(target: "interface", "failed to start interfaces watcher: {initial_watcher_error}");
         }
@@ -372,10 +378,12 @@ impl Devices {
         Self {
             state,
             _timer: timer,
+            #[cfg(feature = "netwatcher")]
             watcher: watcher.into(),
         }
     }
 
+    #[cfg(feature = "netwatcher")]
     #[inline]
     pub fn restart_watcher(&self) -> Result<(), WatcherError> {
         let new_watcher = netwatcher::watch_interfaces_with_callback({


### PR DESCRIPTION
为了解决在安卓上, 两个.a 都依赖了 dhttp, netwatcher 的 static ANDROID_CONTEXT 会导致符号重复的问题