### PR TITLE
chore: prepare dquic v0.7.0-beta.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,14 +100,14 @@ qmacro = { path = "./qmacro", version = "0.5.1" }
 qbase = { path = "./qbase", version = "0.6.0" }
 qevent = { path = "./qevent", version = "0.6.0" }
 qudp = { path = "./qudp", version = "0.6.0" }
-qinterface = { path = "./qinterface", version = "0.6.0" }
+qinterface = { path = "./qinterface", version = "0.7.0-beta.1" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.2" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.3" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.7.0-beta.1" }
-dquic = { path = "./dquic", version = "0.7.0-beta.2" }
+qconnection = { path = "./qconnection", version = "0.7.0-beta.2" }
+dquic = { path = "./dquic", version = "0.7.0-beta.3" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.6.0"
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepare the dquic transport release for tag `v0.7.0-beta.3` after the remote `main` change that makes `netwatcher` opt-in.

## Published crates

- `qinterface` `0.7.0-beta.1`
- `qtraversal` `0.7.0-beta.3`
- `qconnection` `0.7.0-beta.2`
- `dquic` `0.7.0-beta.3`

Unchanged workspace crates keep their existing versions. `h3-shim` remains outside the release surface.

## Version rationale

- `qinterface` moves from `0.6.0` to the `0.7.0` prerelease line because disabling the new `netwatcher` feature removes the previously unconditional `Devices::restart_watcher` API. `cargo-semver-checks` confirms this is a major compatibility change for a `0.x` crate.
- `qtraversal`, `qconnection`, and `dquic` receive prerelease patch increments so their published dependency graph resolves the new `qinterface` line without duplicate incompatible versions.

## Verification

- `git diff --check`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --all-targets --all-features -- -Dwarnings`
- `cargo test --workspace --all-features --all-targets -- --test-threads=1`
- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --no-deps`
- `cargo +1.88.0 build --workspace --release`
- `cargo publish --dry-run --locked --allow-dirty -p qinterface -p qtraversal -p qconnection -p dquic`
- `cargo +1.92.0 semver-checks check-release` against the latest published version of each changed crate; the three prerelease patch surfaces pass, and the `qinterface` probe reports the expected removal that requires the `0.7` line.

## Proposed annotated tag message

```markdown
# dquic v0.7.0-beta.3

## Changes

- Make interface watching opt-in through the `netwatcher` feature across `qinterface`, `qconnection`, and `dquic`.
- Move `qinterface` to the `0.7.0` prerelease compatibility line because its default public API no longer exposes watcher-only methods.
- Keep the published transport dependency graph on one compatible `qinterface` version.

## Published crates

- `qinterface` v0.7.0-beta.1
- `qtraversal` v0.7.0-beta.3
- `qconnection` v0.7.0-beta.2
- `dquic` v0.7.0-beta.3

Unchanged workspace crates remain on their existing published versions. `h3-shim` remains outside the dquic release surface.
```
