### PR TITLE
fix: enforce QUIC path admissibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tracing-appender = "0.2"
 qmacro = { path = "./qmacro", version = "0.5.1" }
 qbase = { path = "./qbase", version = "0.6.0" }
 qevent = { path = "./qevent", version = "0.6.0" }
-qudp = { path = "./qudp", version = "0.6.1" }
+qudp = { path = "./qudp", version = "0.7.0-beta.1" }
 qinterface = { path = "./qinterface", version = "0.7.0-beta.2" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,15 +99,15 @@ tracing-appender = "0.2"
 qmacro = { path = "./qmacro", version = "0.5.1" }
 qbase = { path = "./qbase", version = "0.6.0" }
 qevent = { path = "./qevent", version = "0.6.0" }
-qudp = { path = "./qudp", version = "0.6.0" }
-qinterface = { path = "./qinterface", version = "0.7.0-beta.1" }
+qudp = { path = "./qudp", version = "0.6.1" }
+qinterface = { path = "./qinterface", version = "0.7.0-beta.2" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.3" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.4" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.7.0-beta.2" }
-dquic = { path = "./dquic", version = "0.7.0-beta.3" }
+qconnection = { path = "./qconnection", version = "0.8.0-beta.1" }
+dquic = { path = "./dquic", version = "0.7.0-beta.4" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/dquic/src/client.rs
+++ b/dquic/src/client.rs
@@ -354,9 +354,14 @@ impl QuicClient {
         //   Direct → select/bind interface, construct Link & Pathway, return paths.
         //   Agent  → ensure an interface is bound, return empty paths.
         let paths = self.probe([(source, server_ep)]).await?;
-        let has_direct_path = !paths.is_empty();
+        let mut has_direct_path = false;
         for (iface, link, pathway) in paths {
-            _ = connection.add_path((iface.bind_uri(), pathway, link));
+            match connection.add_path((iface.bind_uri(), pathway, link)) {
+                Ok(()) => has_direct_path = true,
+                Err(error) => {
+                    tracing::trace!(target: "dquic", %error, "skipping probed path candidate");
+                }
+            }
         }
         Ok(has_direct_path)
     }

--- a/dquic/src/server.rs
+++ b/dquic/src/server.rs
@@ -436,9 +436,14 @@ impl QuicListeners {
     )]
     pub(crate) fn try_accept_connection(&self, packet: Packet, (bind_uri, pathway, link): Way) {
         if let Err(error) =
-            qinterface::component::route::validate_way(&(bind_uri.clone(), pathway, link))
+            qinterface::component::route::validate_received_way(&(bind_uri.clone(), pathway, link))
         {
-            tracing::trace!(target: "dquic", %error, "dropping connectless packet on inadmissible path");
+            tracing::trace!(
+                target: "dquic",
+                validation_context = "received_way",
+                %error,
+                "dropping connectless packet on inadmissible path"
+            );
             return;
         }
 
@@ -975,6 +980,27 @@ mod path_admissibility_tests {
             Pathway::from(link),
             link,
         );
+
+        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+
+        assert_eq!(listeners.backlog.available_permits(), 1);
+        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn wildcard_received_initial_does_not_consume_backlog_or_register_odcid() {
+        install_crypto_provider();
+        let router = Arc::new(QuicRouter::new());
+        let listeners = QuicListeners::builder()
+            .with_router(router.clone())
+            .without_client_cert_verifier()
+            .listen(1)
+            .unwrap();
+        let dcid = ConnectionId::from_slice(b"wildcard-path");
+        let local = "0.0.0.0:4433".parse().unwrap();
+        let remote = "203.0.113.10:50000".parse().unwrap();
+        let link = Link::new(local, remote);
+        let way = (BindUri::from(local), Pathway::from(link), link);
 
         listeners.try_accept_connection(initial_packet(dcid), way.clone());
 

--- a/dquic/src/server.rs
+++ b/dquic/src/server.rs
@@ -435,6 +435,13 @@ impl QuicListeners {
         fields(%bind_uri, %pathway, %link, odcid=tracing::field::Empty, server_name=tracing::field::Empty)
     )]
     pub(crate) fn try_accept_connection(&self, packet: Packet, (bind_uri, pathway, link): Way) {
+        if let Err(error) =
+            qinterface::component::route::validate_way(&(bind_uri.clone(), pathway, link))
+        {
+            tracing::trace!(target: "dquic", %error, "dropping connectless packet on inadmissible path");
+            return;
+        }
+
         let origin_dcid = match &packet {
             Packet::Data(data_packet) => match &data_packet.header {
                 DataHeader::Long(LongHeader::Initial(hdr)) => *hdr.dcid(),
@@ -912,5 +919,66 @@ mod local_endpoint_subscription_tests {
         assert!(!production.contains(concat!("subscribe_local_", "address_events")));
         assert!(!production.contains("let listeners = self.clone();"));
         assert!(!production.contains("listeners.subscribe_connection_local_endpoints"));
+    }
+}
+
+#[cfg(test)]
+mod path_admissibility_tests {
+    use std::sync::{Arc, Once};
+
+    use qconnection::{
+        qbase::{
+            cid::ConnectionId,
+            net::route::{Link, Pathway},
+            packet::{
+                DataHeader, DataPacket, LongHeaderBuilder, Packet, long::DataHeader as LongHeader,
+            },
+        },
+        qinterface::{bind_uri::BindUri, component::route::QuicRouter},
+    };
+    use tokio_util::bytes::BytesMut;
+
+    use super::QuicListeners;
+
+    fn install_crypto_provider() {
+        static CRYPTO_PROVIDER: Once = Once::new();
+        CRYPTO_PROVIDER.call_once(|| {
+            _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
+    fn initial_packet(dcid: ConnectionId) -> Packet {
+        let header = LongHeaderBuilder::with_cid(dcid, ConnectionId::from_slice(b"server-test"))
+            .initial(Vec::new());
+        Packet::Data(DataPacket {
+            header: DataHeader::Long(LongHeader::Initial(header)),
+            bytes: BytesMut::new(),
+            offset: 0,
+        })
+    }
+
+    #[tokio::test]
+    async fn invalid_connectless_initial_does_not_consume_backlog_or_register_odcid() {
+        install_crypto_provider();
+        let router = Arc::new(QuicRouter::new());
+        let listeners = QuicListeners::builder()
+            .with_router(router.clone())
+            .without_client_cert_verifier()
+            .listen(1)
+            .unwrap();
+        let dcid = ConnectionId::from_slice(b"invalid-path");
+        let local = "203.0.113.10:4433".parse().unwrap();
+        let remote = "127.0.0.1:50000".parse().unwrap();
+        let link = Link::new(local, remote);
+        let way = (
+            BindUri::from("0.0.0.0:4433".parse::<std::net::SocketAddr>().unwrap()),
+            Pathway::from(link),
+            link,
+        );
+
+        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+
+        assert_eq!(listeners.backlog.available_permits(), 1);
+        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
     }
 }

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.7.0-beta.2"
+version = "0.8.0-beta.1"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -760,12 +760,25 @@ impl Drop for Connection {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Once;
+    use std::{
+        io,
+        sync::{Arc, Once},
+        task::{Context, Poll},
+    };
 
+    use bytes::BytesMut;
     use qbase::{
         error::ErrorKind,
-        net::{addr::EndpointAddr, route::Link},
+        net::{
+            addr::EndpointAddr,
+            route::{Link, Route},
+        },
         token::handy::NoopTokenRegistry,
+    };
+    use qinterface::{
+        bind_uri::BindUri,
+        io::{IO, ProductIO},
+        manager::InterfaceManager,
     };
     use rustls::{
         RootCertStore,
@@ -823,6 +836,91 @@ mod tests {
             .run()
     }
 
+    struct PendingTestIo {
+        bind_uri: BindUri,
+    }
+
+    impl IO for PendingTestIo {
+        fn bind_uri(&self) -> BindUri {
+            self.bind_uri.clone()
+        }
+
+        fn bound_addr(&self) -> io::Result<std::net::SocketAddr> {
+            self.bind_uri.resolve()
+        }
+
+        fn max_segment_size(&self) -> io::Result<usize> {
+            Ok(1200)
+        }
+
+        fn max_segments(&self) -> io::Result<usize> {
+            Ok(1)
+        }
+
+        fn poll_send(
+            &self,
+            _cx: &mut Context<'_>,
+            _pkts: &[io::IoSlice<'_>],
+            _route: Route,
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+
+        fn poll_recv(
+            &self,
+            _cx: &mut Context<'_>,
+            _pkts: &mut [BytesMut],
+            _route: &mut [Route],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+
+        fn poll_close(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct PendingTestIoFactory;
+
+    impl ProductIO for PendingTestIoFactory {
+        fn bind(&self, bind_uri: BindUri) -> Box<dyn IO> {
+            Box::new(PendingTestIo { bind_uri })
+        }
+    }
+
+    #[tokio::test]
+    async fn outbound_wildcard_path_preserves_the_io_owned_source() {
+        let bind_uri: BindUri = "inet://0.0.0.0:50000".parse().unwrap();
+        let interfaces = Arc::new(InterfaceManager::new());
+        let _binding = interfaces
+            .bind(bind_uri.clone(), Arc::new(PendingTestIoFactory))
+            .await;
+        let connection =
+            Connection::new_client("localhost".to_owned(), Arc::new(NoopTokenRegistry))
+                .with_tls_config(test_client_tls_config())
+                .with_iface_manager(interfaces)
+                .with_cids(cid::ConnectionId::from_slice(b"wildcard-source"))
+                .run();
+        let local = "0.0.0.0:50000".parse().unwrap();
+        let remote = "203.0.113.10:4433".parse().unwrap();
+        let way = (
+            bind_uri,
+            Pathway::new(
+                EndpointAddr::direct("192.0.2.10:50000".parse().unwrap()),
+                EndpointAddr::direct(remote),
+            ),
+            Link::new(local, remote),
+        );
+
+        let path = connection
+            .try_map_components(|components| components.get_or_try_create_path(way, false))
+            .expect("connection should remain active")
+            .expect("wildcard outbound candidate should create a path");
+
+        assert_eq!(path.link().src, local);
+        assert!(!path.is_validated_for_test());
+    }
+
     #[tokio::test]
     async fn add_path_rejects_loopback_scope_before_interface_lookup() {
         let connection = test_client_connection();
@@ -869,6 +967,37 @@ mod tests {
             CreatePathFailure::InvalidWay(qinterface::component::route::InvalidWay::Unspecified {
                 side: qinterface::component::route::EndpointSide::Local
             })
+        ));
+    }
+
+    #[tokio::test]
+    async fn received_path_rejects_direct_endpoint_link_mismatch() {
+        let connection = test_client_connection();
+        let local = "127.0.0.1:50000".parse().unwrap();
+        let remote = "127.0.0.1:4433".parse().unwrap();
+        let way = (
+            "inet://127.0.0.1:50000".parse().unwrap(),
+            Pathway::new(
+                EndpointAddr::direct("127.0.0.1:50001".parse().unwrap()),
+                EndpointAddr::direct(remote),
+            ),
+            Link::new(local, remote),
+        );
+
+        let result = connection
+            .try_map_components(|components| components.get_or_try_create_path(way, true))
+            .expect("connection should remain active");
+        let error = match result {
+            Ok(_) => panic!("received Direct endpoint must match its physical Link"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            CreatePathFailure::InvalidWay(
+                qinterface::component::route::InvalidWay::DirectEndpointMismatch {
+                    side: qinterface::component::route::EndpointSide::Local
+                }
+            )
         ));
     }
 

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -847,6 +847,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn received_path_does_not_infer_an_unspecified_packet_destination() {
+        let connection = test_client_connection();
+        let local = "0.0.0.0:50000".parse().unwrap();
+        let remote = "127.0.0.1:4433".parse().unwrap();
+        let way = (
+            "inet://0.0.0.0:50000".parse().unwrap(),
+            Pathway::new(EndpointAddr::direct(local), EndpointAddr::direct(remote)),
+            Link::new(local, remote),
+        );
+
+        let result = connection
+            .try_map_components(|components| components.get_or_try_create_path(way, true))
+            .expect("connection should remain active");
+        let error = match result {
+            Ok(_) => panic!("received paths must carry a concrete packet destination"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            CreatePathFailure::InvalidWay(qinterface::component::route::InvalidWay::Unspecified {
+                side: qinterface::component::route::EndpointSide::Local
+            })
+        ));
+    }
+
+    #[tokio::test]
     async fn validate_without_paths_latches_client_error_and_enters_closing() {
         let connection = test_client_connection();
 

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -430,20 +430,7 @@ impl Components {
     }
 
     fn has_viable_path(&self) -> bool {
-        self.paths
-            .paths::<Vec<_>>()
-            .into_iter()
-            .any(|(pathway, _)| Self::pathway_is_viable(pathway))
-    }
-
-    fn pathway_is_viable(pathway: Pathway) -> bool {
-        if let (EndpointAddr::Direct { addr: local }, EndpointAddr::Direct { addr: remote }) =
-            (pathway.local(), pathway.remote())
-        {
-            local.ip().is_loopback() == remote.ip().is_loopback()
-        } else {
-            true
-        }
+        !self.paths.paths::<Vec<_>>().is_empty()
     }
 }
 
@@ -775,7 +762,11 @@ impl Drop for Connection {
 mod tests {
     use std::sync::Once;
 
-    use qbase::{error::ErrorKind, token::handy::NoopTokenRegistry};
+    use qbase::{
+        error::ErrorKind,
+        net::{addr::EndpointAddr, route::Link},
+        token::handy::NoopTokenRegistry,
+    };
     use rustls::{
         RootCertStore,
         pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject},
@@ -830,6 +821,29 @@ mod tests {
             .with_tls_config(test_server_tls_config())
             .with_cids(cid::ConnectionId::from_slice(b"validate-server"))
             .run()
+    }
+
+    #[tokio::test]
+    async fn add_path_rejects_loopback_scope_before_interface_lookup() {
+        let connection = test_client_connection();
+        let local = "127.0.0.1:50000".parse().unwrap();
+        let remote = "203.0.113.10:4433".parse().unwrap();
+        let way = (
+            "inet://127.0.0.1:50000".parse().unwrap(),
+            Pathway::new(EndpointAddr::direct(local), EndpointAddr::direct(remote)),
+            Link::new(local, remote),
+        );
+
+        let error = connection
+            .add_path(way)
+            .expect_err("mixed loopback scope must be rejected before interface lookup");
+        assert!(matches!(
+            error,
+            CreatePathFailure::InvalidWay(
+                qinterface::component::route::InvalidWay::LoopbackScopeMismatch
+            )
+        ));
+        assert!(!connection.has_viable_path().unwrap());
     }
 
     #[tokio::test]

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -71,13 +71,12 @@ impl Components {
         way: Way,
         is_probed: bool,
     ) -> Result<Arc<Path>, CreatePathFailure> {
-        let way = if is_probed {
-            way
+        let validate = if is_probed {
+            qinterface::component::route::validate_received_way
         } else {
-            qinterface::component::route::resolve_outbound_way(way)
-                .map_err(CreatePathFailure::InvalidWay)?
+            qinterface::component::route::validate_outbound_candidate
         };
-        qinterface::component::route::validate_way(&way).map_err(CreatePathFailure::InvalidWay)?;
+        validate(&way).map_err(CreatePathFailure::InvalidWay)?;
         let (bind_uri, pathway, link) = way;
         let try_create = || {
             let interface = self
@@ -288,6 +287,11 @@ impl Path {
 
     pub fn link(&self) -> &Link {
         &self.link
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_validated_for_test(&self) -> bool {
+        self.validated.load(Ordering::Acquire)
     }
 
     pub fn pathway(&self) -> &Pathway {

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -71,6 +71,8 @@ impl Components {
         way: Way,
         is_probed: bool,
     ) -> Result<Arc<Path>, CreatePathFailure> {
+        let way = qinterface::component::route::resolve_way(way)
+            .map_err(CreatePathFailure::InvalidWay)?;
         qinterface::component::route::validate_way(&way).map_err(CreatePathFailure::InvalidWay)?;
         let (bind_uri, pathway, link) = way;
         let try_create = || {

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -71,8 +71,12 @@ impl Components {
         way: Way,
         is_probed: bool,
     ) -> Result<Arc<Path>, CreatePathFailure> {
-        let way = qinterface::component::route::resolve_way(way)
-            .map_err(CreatePathFailure::InvalidWay)?;
+        let way = if is_probed {
+            way
+        } else {
+            qinterface::component::route::resolve_outbound_way(way)
+                .map_err(CreatePathFailure::InvalidWay)?
+        };
         qinterface::component::route::validate_way(&way).map_err(CreatePathFailure::InvalidWay)?;
         let (bind_uri, pathway, link) = way;
         let try_create = || {

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -68,9 +68,11 @@ pub struct Path {
 impl Components {
     pub fn get_or_try_create_path(
         &self,
-        (bind_uri, pathway, link): Way,
+        way: Way,
         is_probed: bool,
     ) -> Result<Arc<Path>, CreatePathFailure> {
+        qinterface::component::route::validate_way(&way).map_err(CreatePathFailure::InvalidWay)?;
+        let (bind_uri, pathway, link) = way;
         let try_create = || {
             let interface = self
                 .interfaces

--- a/qconnection/src/path/error.rs
+++ b/qconnection/src/path/error.rs
@@ -8,6 +8,8 @@ use crate::path::validate::ValidateFailure;
 
 #[derive(Debug, From, Error)]
 pub enum CreatePathFailure {
+    #[error(transparent)]
+    InvalidWay(qinterface::component::route::InvalidWay),
     #[error("Network interface not found for bind URI: {0}")]
     NoInterface(BindUri),
     #[error("Connection is closed")]

--- a/qconnection/src/space/data.rs
+++ b/qconnection/src/space/data.rs
@@ -433,6 +433,10 @@ async fn parse_normal_zero_rtt_packet(
             packet.drop_on_conenction_closed();
             return Ok(());
         }
+        Err(CreatePathFailure::InvalidWay(error)) => {
+            tracing::trace!(target: "dquic", %error, "dropping 0-RTT packet on inadmissible path");
+            return Ok(());
+        }
         Err(CreatePathFailure::NoInterface(..)) => {
             packet.drop_on_interface_not_found();
             return Ok(());
@@ -471,6 +475,10 @@ async fn parse_normal_one_rtt_packet(
         Ok(path) => path,
         Err(CreatePathFailure::ConnectionClosed(..)) => {
             packet.drop_on_conenction_closed();
+            return Ok(());
+        }
+        Err(CreatePathFailure::InvalidWay(error)) => {
+            tracing::trace!(target: "dquic", %error, "dropping 1-RTT packet on inadmissible path");
             return Ok(());
         }
         Err(CreatePathFailure::NoInterface(..)) => {

--- a/qconnection/src/space/handshake.rs
+++ b/qconnection/src/space/handshake.rs
@@ -197,6 +197,10 @@ async fn parse_normal_packet(
             packet.drop_on_conenction_closed();
             return Ok(());
         }
+        Err(CreatePathFailure::InvalidWay(error)) => {
+            tracing::trace!(target: "dquic", %error, "dropping Handshake packet on inadmissible path");
+            return Ok(());
+        }
         Err(CreatePathFailure::NoInterface(..)) => {
             packet.drop_on_interface_not_found();
             return Ok(());

--- a/qconnection/src/space/initial.rs
+++ b/qconnection/src/space/initial.rs
@@ -234,6 +234,10 @@ async fn parse_normal_packet(
             packet.drop_on_conenction_closed();
             return Ok(());
         }
+        Err(CreatePathFailure::InvalidWay(error)) => {
+            tracing::trace!(target: "dquic", %error, "dropping Initial packet on inadmissible path");
+            return Ok(());
+        }
         Err(CreatePathFailure::NoInterface(..)) => {
             packet.drop_on_interface_not_found();
             return Ok(());

--- a/qconnection/src/traversal.rs
+++ b/qconnection/src/traversal.rs
@@ -38,10 +38,16 @@ impl ReceiveFrame<(BindUri, Pathway, Link, PunchHelloFrame)> for Components {
 }
 
 impl Components {
+    fn add_resolved_path(&self, way: Way) {
+        if let Err(error) = self.add_path(way) {
+            tracing::trace!(target: "dquic", %error, "skipping resolved path candidate");
+        }
+    }
+
     fn apply_local_endpoint_path_changes(&self, changes: LocalEndpointPathChanges) {
         for change in changes {
             if let LocalEndpointPathChange::AddPath(way) = change {
-                let _ = self.add_path(way);
+                self.add_resolved_path(way);
             }
         }
     }
@@ -82,7 +88,7 @@ impl Components {
                 );
                 ways.into_iter().for_each(|(bind_uri, link, pathway)| {
                     let way: Way = (bind_uri, pathway, link);
-                    let _ = self.add_path(way);
+                    self.add_resolved_path(way);
                 });
             }
             Err(error) => {

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -17,11 +17,13 @@ use qbase::{
 };
 
 use crate::{BindUri, Interface, component::Component};
+mod admissibility;
 mod handler;
 mod packet;
 mod queue;
 pub type Way = (BindUri, Pathway, Link);
 
+pub use admissibility::{EndpointSide, InvalidWay, validate_way};
 pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -23,7 +23,7 @@ mod packet;
 mod queue;
 pub type Way = (BindUri, Pathway, Link);
 
-pub use admissibility::{EndpointSide, InvalidWay, validate_way};
+pub use admissibility::{EndpointSide, InvalidWay, resolve_way, validate_way};
 pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -23,7 +23,7 @@ mod packet;
 mod queue;
 pub type Way = (BindUri, Pathway, Link);
 
-pub use admissibility::{EndpointSide, InvalidWay, resolve_way, validate_way};
+pub use admissibility::{EndpointSide, InvalidWay, resolve_outbound_way, validate_way};
 pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -23,7 +23,9 @@ mod packet;
 mod queue;
 pub type Way = (BindUri, Pathway, Link);
 
-pub use admissibility::{EndpointSide, InvalidWay, resolve_outbound_way, validate_way};
+pub use admissibility::{
+    EndpointSide, InvalidWay, validate_outbound_candidate, validate_received_way,
+};
 pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -85,6 +85,39 @@ fn is_loopback(ip: IpAddr) -> bool {
     }
 }
 
+fn validate_link_local_pair(
+    local: SocketAddr,
+    remote: SocketAddr,
+    allow_unspecified_local: bool,
+) -> Result<(), InvalidWay> {
+    if !is_link_local(remote.ip()) {
+        return Ok(());
+    }
+
+    let local_is_unspecified = is_unspecified(local.ip());
+    if local_is_unspecified {
+        if !allow_unspecified_local {
+            return Err(InvalidWay::LinkLocalScopeMismatch);
+        }
+    } else if !is_link_local(local.ip()) {
+        return Err(InvalidWay::LinkLocalScopeMismatch);
+    }
+
+    if let SocketAddr::V6(remote) = remote {
+        if remote.scope_id() == 0 {
+            return Err(InvalidWay::LinkLocalScopeMismatch);
+        }
+        if let SocketAddr::V6(local) = local
+            && !local_is_unspecified
+            && (local.scope_id() == 0 || local.scope_id() != remote.scope_id())
+        {
+            return Err(InvalidWay::LinkLocalScopeMismatch);
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Clone, Copy)]
 enum Evidence {
     OutboundCandidate,
@@ -125,12 +158,13 @@ fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), Inval
         });
     }
 
-    if let Some(bound) = bind.as_inet_bind_uri()
-        && !bound.ip().is_unspecified()
-        && !local_is_unspecified
-        && (bound.ip() != local.ip() || (bound.port() != 0 && bound.port() != local.port()))
-    {
-        return Err(InvalidWay::BindAddressMismatch { bound, local });
+    if let Some(bound) = bind.as_inet_bind_uri() {
+        let ip_mismatch =
+            !bound.ip().is_unspecified() && !local_is_unspecified && bound.ip() != local.ip();
+        let port_mismatch = bound.port() != 0 && bound.port() != local.port();
+        if ip_mismatch || port_mismatch {
+            return Err(InvalidWay::BindAddressMismatch { bound, local });
+        }
     }
 
     if matches!(pathway.local(), EndpointAddr::Direct { addr } if !local_is_unspecified && addr != local)
@@ -171,24 +205,18 @@ fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), Inval
                 return Err(InvalidWay::LoopbackScopeMismatch);
             }
         }
+        validate_link_local_pair(
+            local,
+            remote,
+            matches!(evidence, Evidence::OutboundCandidate),
+        )?;
     }
 
-    if is_link_local(remote.ip()) {
-        if !local_is_unspecified && !is_link_local(local.ip()) {
-            return Err(InvalidWay::LinkLocalScopeMismatch);
-        }
-        if let SocketAddr::V6(remote) = remote {
-            if remote.scope_id() == 0 {
-                return Err(InvalidWay::LinkLocalScopeMismatch);
-            }
-            if let SocketAddr::V6(local) = local
-                && !local_is_unspecified
-                && (local.scope_id() == 0 || local.scope_id() != remote.scope_id())
-            {
-                return Err(InvalidWay::LinkLocalScopeMismatch);
-            }
-        }
-    }
+    validate_link_local_pair(
+        local,
+        remote,
+        matches!(evidence, Evidence::OutboundCandidate),
+    )?;
 
     Ok(())
 }
@@ -493,6 +521,30 @@ mod tests {
 
         assert_eq!(
             validate_received_way(&candidate),
+            Err(InvalidWay::LinkLocalScopeMismatch)
+        );
+    }
+
+    #[test]
+    fn wildcard_inet_bind_port_still_constrains_the_candidate() {
+        let candidate = way("inet://0.0.0.0:50001", "0.0.0.0:50000", "203.0.113.10:4433");
+
+        assert!(matches!(
+            validate_outbound_candidate(&candidate),
+            Err(InvalidWay::BindAddressMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn outbound_direct_link_local_intent_requires_compatible_scopes() {
+        let mut candidate = way("inet://[::]:50000", "[::]:50000", "[fe80::2%3]:4433");
+        candidate.1 = Pathway::new(
+            EndpointAddr::direct("[fe80::1]:50000".parse().unwrap()),
+            candidate.1.remote(),
+        );
+
+        assert_eq!(
+            validate_outbound_candidate(&candidate),
             Err(InvalidWay::LinkLocalScopeMismatch)
         );
     }

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -1,6 +1,6 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use qbase::net::{Family, addr::EndpointAddr, route::Pathway};
+use qbase::net::{Family, addr::EndpointAddr};
 use thiserror::Error;
 
 use super::Way;
@@ -33,51 +33,11 @@ pub enum InvalidWay {
     DirectEndpointMismatch { side: EndpointSide },
     #[error("link-local peer is missing a compatible interface scope")]
     LinkLocalScopeMismatch,
-    #[error("bind URI cannot currently resolve to an interface")]
-    BindUnavailable,
-    #[error("kernel route lookup could not select a concrete local address")]
-    LocalAddressUnavailable,
     #[error("concrete local address {local} does not match bind address {bound}")]
     BindAddressMismatch {
         bound: SocketAddr,
         local: SocketAddr,
     },
-}
-
-fn route_local_addr(remote: SocketAddr, port: u16) -> Result<SocketAddr, InvalidWay> {
-    let wildcard = match remote {
-        SocketAddr::V4(..) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
-        SocketAddr::V6(..) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
-    };
-    let socket = UdpSocket::bind(wildcard).map_err(|_| InvalidWay::LocalAddressUnavailable)?;
-    socket
-        .connect(remote)
-        .map_err(|_| InvalidWay::LocalAddressUnavailable)?;
-    let selected = socket
-        .local_addr()
-        .map_err(|_| InvalidWay::LocalAddressUnavailable)?;
-    Ok(SocketAddr::new(selected.ip(), port))
-}
-
-pub fn resolve_outbound_way((bind, pathway, mut link): Way) -> Result<Way, InvalidWay> {
-    if !link.src.ip().is_unspecified() {
-        return Ok((bind, pathway, link));
-    }
-
-    let binding = bind
-        .resolve_binding()
-        .map_err(|_| InvalidWay::BindUnavailable)?;
-    let resolved_local = if binding.addr.ip().is_unspecified() {
-        route_local_addr(link.dst, link.src.port())?
-    } else {
-        SocketAddr::new(binding.addr.ip(), link.src.port())
-    };
-    let local_endpoint = match pathway.local() {
-        EndpointAddr::Direct { addr } if addr == link.src => EndpointAddr::direct(resolved_local),
-        endpoint => endpoint,
-    };
-    link.src = resolved_local;
-    Ok((bind, Pathway::new(local_endpoint, pathway.remote()), link))
 }
 
 fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), InvalidWay> {
@@ -120,9 +80,24 @@ fn is_loopback(ip: IpAddr) -> bool {
     }
 }
 
-pub fn validate_way((bind, pathway, link): &Way) -> Result<(), InvalidWay> {
+#[derive(Clone, Copy)]
+enum Evidence {
+    OutboundCandidate,
+    Received,
+}
+
+pub fn validate_outbound_candidate(way: &Way) -> Result<(), InvalidWay> {
+    validate(way, Evidence::OutboundCandidate)
+}
+
+pub fn validate_received_way(way: &Way) -> Result<(), InvalidWay> {
+    validate(way, Evidence::Received)
+}
+
+fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), InvalidWay> {
     let local = link.src;
     let remote = link.dst;
+    let local_is_unspecified = local.ip().is_unspecified();
 
     if local.is_ipv4() != remote.is_ipv4() {
         return Err(InvalidWay::AddressFamilyMismatch);
@@ -135,12 +110,26 @@ pub fn validate_way((bind, pathway, link): &Way) -> Result<(), InvalidWay> {
     if bind.family() != link_family {
         return Err(InvalidWay::BindFamilyMismatch);
     }
-    validate_endpoint(EndpointSide::Local, local)?;
+
     validate_endpoint(EndpointSide::Remote, remote)?;
-    if local == remote {
-        return Err(InvalidWay::IdenticalEndpoints);
+    if !matches!(evidence, Evidence::OutboundCandidate) || !local_is_unspecified {
+        validate_endpoint(EndpointSide::Local, local)?;
+    } else if local.port() == 0 {
+        return Err(InvalidWay::ZeroPort {
+            side: EndpointSide::Local,
+        });
     }
-    if matches!(pathway.local(), EndpointAddr::Direct { addr } if addr != local) {
+
+    if let Some(bound) = bind.as_inet_bind_uri()
+        && !bound.ip().is_unspecified()
+        && !local_is_unspecified
+        && bound.ip() != local.ip()
+    {
+        return Err(InvalidWay::BindAddressMismatch { bound, local });
+    }
+
+    if matches!(pathway.local(), EndpointAddr::Direct { addr } if !local_is_unspecified && addr != local)
+    {
         return Err(InvalidWay::DirectEndpointMismatch {
             side: EndpointSide::Local,
         });
@@ -150,39 +139,38 @@ pub fn validate_way((bind, pathway, link): &Way) -> Result<(), InvalidWay> {
             side: EndpointSide::Remote,
         });
     }
-    if is_loopback(local.ip()) != is_loopback(remote.ip()) {
+
+    if !local_is_unspecified {
+        if local == remote {
+            return Err(InvalidWay::IdenticalEndpoints);
+        }
+        if is_loopback(local.ip()) != is_loopback(remote.ip()) {
+            return Err(InvalidWay::LoopbackScopeMismatch);
+        }
+    }
+
+    if let (EndpointAddr::Direct { addr: local }, EndpointAddr::Direct { addr: remote }) =
+        (pathway.local(), pathway.remote())
+        && !local.ip().is_unspecified()
+        && !remote.ip().is_unspecified()
+        && is_loopback(local.ip()) != is_loopback(remote.ip())
+    {
         return Err(InvalidWay::LoopbackScopeMismatch);
     }
 
-    let binding = bind
-        .resolve_binding()
-        .map_err(|_| InvalidWay::BindUnavailable)?;
-    let bound = binding.addr;
-    if !bound.ip().is_unspecified() && bound.ip() != local.ip() {
-        return Err(InvalidWay::BindAddressMismatch { bound, local });
-    }
-
     if is_link_local(remote.ip()) {
-        match binding.device {
-            Some(device) => {
-                if let SocketAddr::V6(remote) = remote
-                    && remote.scope_id() != 0
-                    && remote.scope_id() != device.index
-                {
-                    return Err(InvalidWay::LinkLocalScopeMismatch);
-                }
+        if !local_is_unspecified && !is_link_local(local.ip()) {
+            return Err(InvalidWay::LinkLocalScopeMismatch);
+        }
+        if let SocketAddr::V6(remote) = remote {
+            if remote.scope_id() == 0 {
+                return Err(InvalidWay::LinkLocalScopeMismatch);
             }
-            None => {
-                if !is_link_local(local.ip()) {
-                    return Err(InvalidWay::LinkLocalScopeMismatch);
-                }
-                if let (SocketAddr::V6(local), SocketAddr::V6(remote)) = (local, remote) {
-                    let local_scope = local.scope_id();
-                    let remote_scope = remote.scope_id();
-                    if remote_scope == 0 || (local_scope != 0 && local_scope != remote_scope) {
-                        return Err(InvalidWay::LinkLocalScopeMismatch);
-                    }
-                }
+            if let SocketAddr::V6(local) = local
+                && local.scope_id() != 0
+                && local.scope_id() != remote.scope_id()
+            {
+                return Err(InvalidWay::LinkLocalScopeMismatch);
             }
         }
     }
@@ -236,22 +224,67 @@ mod tests {
                 "[2001:db8::2]:4433",
             ),
         ] {
-            assert_eq!(validate_way(&candidate), Ok(()), "{candidate:?}");
+            assert_eq!(
+                validate_outbound_candidate(&candidate),
+                Ok(()),
+                "{candidate:?}"
+            );
+            assert_eq!(validate_received_way(&candidate), Ok(()), "{candidate:?}");
         }
     }
 
     #[test]
-    fn resolves_wildcard_local_address_using_the_remote_route() {
-        let candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "127.0.0.1:4433");
+    fn outbound_wildcard_local_is_preserved() {
+        let candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "203.0.113.10:4433");
 
-        let resolved =
-            resolve_outbound_way(candidate).expect("loopback route should resolve locally");
-        assert_eq!(resolved.2.src, "127.0.0.1:50000".parse().unwrap());
+        assert_eq!(validate_outbound_candidate(&candidate), Ok(()));
+        assert_eq!(candidate.2.src, "0.0.0.0:50000".parse().unwrap());
+    }
+
+    #[test]
+    fn received_wildcard_local_is_rejected() {
+        let received = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "203.0.113.10:4433");
+
         assert_eq!(
-            resolved.1.local(),
-            EndpointAddr::direct("127.0.0.1:50000".parse().unwrap())
+            validate_received_way(&received),
+            Err(InvalidWay::Unspecified {
+                side: EndpointSide::Local,
+            })
         );
-        assert_eq!(validate_way(&resolved), Ok(()));
+    }
+
+    #[test]
+    fn outbound_wildcard_link_accepts_concrete_direct_intent() {
+        let mut candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "203.0.113.10:4433");
+        candidate.1 = Pathway::new(
+            EndpointAddr::direct("192.0.2.10:50000".parse().unwrap()),
+            candidate.1.remote(),
+        );
+
+        assert_eq!(validate_outbound_candidate(&candidate), Ok(()));
+        assert_eq!(
+            validate_received_way(&candidate),
+            Err(InvalidWay::Unspecified {
+                side: EndpointSide::Local,
+            })
+        );
+    }
+
+    #[test]
+    fn neither_context_accepts_a_wildcard_remote() {
+        let candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "0.0.0.0:4433");
+
+        for result in [
+            validate_outbound_candidate(&candidate),
+            validate_received_way(&candidate),
+        ] {
+            assert_eq!(
+                result,
+                Err(InvalidWay::Unspecified {
+                    side: EndpointSide::Remote,
+                })
+            );
+        }
     }
 
     #[test]
@@ -273,17 +306,19 @@ mod tests {
                 "[::ffff:203.0.113.10]:4433",
             ),
         ] {
-            assert_eq!(
-                validate_way(&candidate),
-                Err(InvalidWay::LoopbackScopeMismatch)
-            );
+            for result in [
+                validate_outbound_candidate(&candidate),
+                validate_received_way(&candidate),
+            ] {
+                assert_eq!(result, Err(InvalidWay::LoopbackScopeMismatch));
+            }
         }
     }
 
     #[test]
     fn rejects_non_path_endpoints() {
         assert!(matches!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://0.0.0.0:50000",
                 "0.0.0.0:50000",
                 "203.0.113.10:4433"
@@ -293,7 +328,7 @@ mod tests {
             })
         ));
         assert!(matches!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.10:50000",
                 "192.168.1.10:50000",
                 "224.0.0.1:4433"
@@ -303,7 +338,7 @@ mod tests {
             })
         ));
         assert!(matches!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.10:50000",
                 "192.168.1.10:50000",
                 "255.255.255.255:4433"
@@ -313,7 +348,7 @@ mod tests {
             })
         ));
         assert!(matches!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.10:50000",
                 "192.168.1.10:50000",
                 "203.0.113.10:0"
@@ -327,7 +362,7 @@ mod tests {
     #[test]
     fn rejects_family_identity_bind_and_link_local_scope_mismatches() {
         assert_eq!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.10:50000",
                 "192.168.1.10:50000",
                 "[2001:db8::2]:4433"
@@ -335,7 +370,7 @@ mod tests {
             Err(InvalidWay::AddressFamilyMismatch)
         );
         assert_eq!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.10:4433",
                 "192.168.1.10:4433",
                 "192.168.1.10:4433"
@@ -343,7 +378,7 @@ mod tests {
             Err(InvalidWay::IdenticalEndpoints)
         );
         assert!(matches!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://192.168.1.11:50000",
                 "192.168.1.10:50000",
                 "203.0.113.10:4433"
@@ -351,7 +386,7 @@ mod tests {
             Err(InvalidWay::BindAddressMismatch { .. })
         ));
         assert_eq!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://[2001:db8::1]:50000",
                 "[2001:db8::1]:50000",
                 "[fe80::2]:4433"
@@ -359,7 +394,7 @@ mod tests {
             Err(InvalidWay::LinkLocalScopeMismatch)
         );
         assert_eq!(
-            validate_way(&way(
+            validate_received_way(&way(
                 "inet://[::]:50000",
                 "[fe80::1%3]:50000",
                 "[fe80::2]:4433"
@@ -379,25 +414,28 @@ mod tests {
             EndpointAddr::direct("127.0.0.1:50001".parse().unwrap()),
             candidate.1.remote(),
         );
-        assert_eq!(
-            validate_way(&candidate),
-            Err(InvalidWay::DirectEndpointMismatch {
-                side: EndpointSide::Local
-            })
-        );
+        for result in [
+            validate_outbound_candidate(&candidate),
+            validate_received_way(&candidate),
+        ] {
+            assert_eq!(
+                result,
+                Err(InvalidWay::DirectEndpointMismatch {
+                    side: EndpointSide::Local
+                })
+            );
+        }
     }
 
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn iface_bind_rejects_an_address_not_owned_by_that_device() {
+    #[test]
+    fn iface_bind_validation_does_not_resolve_the_device() {
         let candidate = way(
-            "iface://v4.lo:50000",
+            "iface://v4.nonexistent:50000",
             "203.0.113.10:50000",
             "198.51.100.10:4433",
         );
-        assert!(matches!(
-            validate_way(&candidate),
-            Err(InvalidWay::BindAddressMismatch { .. })
-        ));
+
+        assert_eq!(validate_outbound_candidate(&candidate), Ok(()));
+        assert_eq!(validate_received_way(&candidate), Ok(()));
     }
 }

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -1,6 +1,6 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 
-use qbase::net::Family;
+use qbase::net::{Family, addr::EndpointAddr, route::Pathway};
 use thiserror::Error;
 
 use super::Way;
@@ -33,11 +33,49 @@ pub enum InvalidWay {
     LinkLocalScopeMismatch,
     #[error("bind URI cannot currently resolve to an interface")]
     BindUnavailable,
+    #[error("kernel route lookup could not select a concrete local address")]
+    LocalAddressUnavailable,
     #[error("concrete local address {local} does not match bind address {bound}")]
     BindAddressMismatch {
         bound: SocketAddr,
         local: SocketAddr,
     },
+}
+
+fn route_local_addr(remote: SocketAddr, port: u16) -> Result<SocketAddr, InvalidWay> {
+    let wildcard = match remote {
+        SocketAddr::V4(..) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
+        SocketAddr::V6(..) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
+    };
+    let socket = UdpSocket::bind(wildcard).map_err(|_| InvalidWay::LocalAddressUnavailable)?;
+    socket
+        .connect(remote)
+        .map_err(|_| InvalidWay::LocalAddressUnavailable)?;
+    let selected = socket
+        .local_addr()
+        .map_err(|_| InvalidWay::LocalAddressUnavailable)?;
+    Ok(SocketAddr::new(selected.ip(), port))
+}
+
+pub fn resolve_way((bind, pathway, mut link): Way) -> Result<Way, InvalidWay> {
+    if !link.src.ip().is_unspecified() {
+        return Ok((bind, pathway, link));
+    }
+
+    let binding = bind
+        .resolve_binding()
+        .map_err(|_| InvalidWay::BindUnavailable)?;
+    let resolved_local = if binding.addr.ip().is_unspecified() {
+        route_local_addr(link.dst, link.src.port())?
+    } else {
+        SocketAddr::new(binding.addr.ip(), link.src.port())
+    };
+    let local_endpoint = match pathway.local() {
+        EndpointAddr::Direct { addr } if addr == link.src => EndpointAddr::direct(resolved_local),
+        endpoint => endpoint,
+    };
+    link.src = resolved_local;
+    Ok((bind, Pathway::new(local_endpoint, pathway.remote()), link))
 }
 
 fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), InvalidWay> {
@@ -173,6 +211,19 @@ mod tests {
         ] {
             assert_eq!(validate_way(&candidate), Ok(()), "{candidate:?}");
         }
+    }
+
+    #[test]
+    fn resolves_wildcard_local_address_using_the_remote_route() {
+        let candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "127.0.0.1:4433");
+
+        let resolved = resolve_way(candidate).expect("loopback route should resolve locally");
+        assert_eq!(resolved.2.src, "127.0.0.1:50000".parse().unwrap());
+        assert_eq!(
+            resolved.1.local(),
+            EndpointAddr::direct("127.0.0.1:50000".parse().unwrap())
+        );
+        assert_eq!(validate_way(&resolved), Ok(()));
     }
 
     #[test]

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -40,12 +40,17 @@ pub enum InvalidWay {
     },
 }
 
+fn is_unspecified(ip: IpAddr) -> bool {
+    ip.is_unspecified()
+        || matches!(ip, IpAddr::V6(ip) if ip.to_ipv4_mapped().is_some_and(|ip| ip.is_unspecified()))
+}
+
 fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), InvalidWay> {
     let mapped_ipv4 = match addr.ip() {
         IpAddr::V6(ip) => ip.to_ipv4_mapped(),
         IpAddr::V4(..) => None,
     };
-    if addr.ip().is_unspecified() || mapped_ipv4.is_some_and(|ip| ip.is_unspecified()) {
+    if is_unspecified(addr.ip()) {
         return Err(InvalidWay::Unspecified { side });
     }
     if addr.port() == 0 {
@@ -97,7 +102,7 @@ pub fn validate_received_way(way: &Way) -> Result<(), InvalidWay> {
 fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), InvalidWay> {
     let local = link.src;
     let remote = link.dst;
-    let local_is_unspecified = local.ip().is_unspecified();
+    let local_is_unspecified = is_unspecified(local.ip());
 
     if local.is_ipv4() != remote.is_ipv4() {
         return Err(InvalidWay::AddressFamilyMismatch);
@@ -123,7 +128,7 @@ fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), Inval
     if let Some(bound) = bind.as_inet_bind_uri()
         && !bound.ip().is_unspecified()
         && !local_is_unspecified
-        && bound.ip() != local.ip()
+        && (bound.ip() != local.ip() || (bound.port() != 0 && bound.port() != local.port()))
     {
         return Err(InvalidWay::BindAddressMismatch { bound, local });
     }
@@ -151,11 +156,21 @@ fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), Inval
 
     if let (EndpointAddr::Direct { addr: local }, EndpointAddr::Direct { addr: remote }) =
         (pathway.local(), pathway.remote())
-        && !local.ip().is_unspecified()
-        && !remote.ip().is_unspecified()
-        && is_loopback(local.ip()) != is_loopback(remote.ip())
     {
-        return Err(InvalidWay::LoopbackScopeMismatch);
+        let local_is_unspecified = is_unspecified(local.ip());
+        if local.is_ipv4() != remote.is_ipv4() {
+            return Err(InvalidWay::AddressFamilyMismatch);
+        }
+        validate_endpoint(EndpointSide::Remote, remote)?;
+        if !local_is_unspecified {
+            validate_endpoint(EndpointSide::Local, local)?;
+            if local == remote {
+                return Err(InvalidWay::IdenticalEndpoints);
+            }
+            if is_loopback(local.ip()) != is_loopback(remote.ip()) {
+                return Err(InvalidWay::LoopbackScopeMismatch);
+            }
+        }
     }
 
     if is_link_local(remote.ip()) {
@@ -167,8 +182,8 @@ fn validate((bind, pathway, link): &Way, evidence: Evidence) -> Result<(), Inval
                 return Err(InvalidWay::LinkLocalScopeMismatch);
             }
             if let SocketAddr::V6(local) = local
-                && local.scope_id() != 0
-                && local.scope_id() != remote.scope_id()
+                && !local_is_unspecified
+                && (local.scope_id() == 0 || local.scope_id() != remote.scope_id())
             {
                 return Err(InvalidWay::LinkLocalScopeMismatch);
             }
@@ -437,5 +452,48 @@ mod tests {
 
         assert_eq!(validate_outbound_candidate(&candidate), Ok(()));
         assert_eq!(validate_received_way(&candidate), Ok(()));
+    }
+
+    #[test]
+    fn outbound_direct_intent_must_match_the_physical_family() {
+        let mut candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "203.0.113.10:4433");
+        candidate.1 = Pathway::new(
+            EndpointAddr::direct("[2001:db8::1]:50000".parse().unwrap()),
+            candidate.1.remote(),
+        );
+
+        assert_eq!(
+            validate_outbound_candidate(&candidate),
+            Err(InvalidWay::AddressFamilyMismatch)
+        );
+    }
+
+    #[test]
+    fn concrete_inet_bind_port_must_match_the_link() {
+        let candidate = way(
+            "inet://192.0.2.10:50001",
+            "192.0.2.10:50000",
+            "203.0.113.10:4433",
+        );
+
+        for result in [
+            validate_outbound_candidate(&candidate),
+            validate_received_way(&candidate),
+        ] {
+            assert!(matches!(
+                result,
+                Err(InvalidWay::BindAddressMismatch { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn received_ipv6_link_local_scopes_must_both_be_concrete() {
+        let candidate = way("inet://[::]:50000", "[fe80::1]:50000", "[fe80::2%3]:4433");
+
+        assert_eq!(
+            validate_received_way(&candidate),
+            Err(InvalidWay::LinkLocalScopeMismatch)
+        );
     }
 }

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -29,6 +29,8 @@ pub enum InvalidWay {
     Broadcast { side: EndpointSide },
     #[error("local and remote concrete endpoints are identical")]
     IdenticalEndpoints,
+    #[error("{side:?} direct endpoint does not match the concrete path address")]
+    DirectEndpointMismatch { side: EndpointSide },
     #[error("link-local peer is missing a compatible interface scope")]
     LinkLocalScopeMismatch,
     #[error("bind URI cannot currently resolve to an interface")]
@@ -57,7 +59,7 @@ fn route_local_addr(remote: SocketAddr, port: u16) -> Result<SocketAddr, Invalid
     Ok(SocketAddr::new(selected.ip(), port))
 }
 
-pub fn resolve_way((bind, pathway, mut link): Way) -> Result<Way, InvalidWay> {
+pub fn resolve_outbound_way((bind, pathway, mut link): Way) -> Result<Way, InvalidWay> {
     if !link.src.ip().is_unspecified() {
         return Ok((bind, pathway, link));
     }
@@ -79,16 +81,22 @@ pub fn resolve_way((bind, pathway, mut link): Way) -> Result<Way, InvalidWay> {
 }
 
 fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), InvalidWay> {
-    if addr.ip().is_unspecified() {
+    let mapped_ipv4 = match addr.ip() {
+        IpAddr::V6(ip) => ip.to_ipv4_mapped(),
+        IpAddr::V4(..) => None,
+    };
+    if addr.ip().is_unspecified() || mapped_ipv4.is_some_and(|ip| ip.is_unspecified()) {
         return Err(InvalidWay::Unspecified { side });
     }
     if addr.port() == 0 {
         return Err(InvalidWay::ZeroPort { side });
     }
-    if addr.ip().is_multicast() {
+    if addr.ip().is_multicast() || mapped_ipv4.is_some_and(|ip| ip.is_multicast()) {
         return Err(InvalidWay::Multicast { side });
     }
-    if matches!(addr.ip(), IpAddr::V4(ip) if ip == Ipv4Addr::BROADCAST) {
+    if matches!(addr.ip(), IpAddr::V4(ip) if ip == Ipv4Addr::BROADCAST)
+        || mapped_ipv4 == Some(Ipv4Addr::BROADCAST)
+    {
         return Err(InvalidWay::Broadcast { side });
     }
     Ok(())
@@ -97,11 +105,22 @@ fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), Invalid
 fn is_link_local(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(ip) => ip.is_link_local(),
-        IpAddr::V6(ip) => ip.is_unicast_link_local(),
+        IpAddr::V6(ip) => {
+            ip.is_unicast_link_local() || ip.to_ipv4_mapped().is_some_and(|ip| ip.is_link_local())
+        }
     }
 }
 
-pub fn validate_way((bind, _pathway, link): &Way) -> Result<(), InvalidWay> {
+fn is_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_loopback(),
+        IpAddr::V6(ip) => {
+            ip.is_loopback() || ip.to_ipv4_mapped().is_some_and(|ip| ip.is_loopback())
+        }
+    }
+}
+
+pub fn validate_way((bind, pathway, link): &Way) -> Result<(), InvalidWay> {
     let local = link.src;
     let remote = link.dst;
 
@@ -121,7 +140,17 @@ pub fn validate_way((bind, _pathway, link): &Way) -> Result<(), InvalidWay> {
     if local == remote {
         return Err(InvalidWay::IdenticalEndpoints);
     }
-    if local.ip().is_loopback() != remote.ip().is_loopback() {
+    if matches!(pathway.local(), EndpointAddr::Direct { addr } if addr != local) {
+        return Err(InvalidWay::DirectEndpointMismatch {
+            side: EndpointSide::Local,
+        });
+    }
+    if matches!(pathway.remote(), EndpointAddr::Direct { addr } if addr != remote) {
+        return Err(InvalidWay::DirectEndpointMismatch {
+            side: EndpointSide::Remote,
+        });
+    }
+    if is_loopback(local.ip()) != is_loopback(remote.ip()) {
         return Err(InvalidWay::LoopbackScopeMismatch);
     }
 
@@ -150,9 +179,7 @@ pub fn validate_way((bind, _pathway, link): &Way) -> Result<(), InvalidWay> {
                 if let (SocketAddr::V6(local), SocketAddr::V6(remote)) = (local, remote) {
                     let local_scope = local.scope_id();
                     let remote_scope = remote.scope_id();
-                    if (local_scope == 0 && remote_scope == 0)
-                        || (local_scope != 0 && remote_scope != 0 && local_scope != remote_scope)
-                    {
+                    if remote_scope == 0 || (local_scope != 0 && local_scope != remote_scope) {
                         return Err(InvalidWay::LinkLocalScopeMismatch);
                     }
                 }
@@ -217,7 +244,8 @@ mod tests {
     fn resolves_wildcard_local_address_using_the_remote_route() {
         let candidate = way("inet://0.0.0.0:50000", "0.0.0.0:50000", "127.0.0.1:4433");
 
-        let resolved = resolve_way(candidate).expect("loopback route should resolve locally");
+        let resolved =
+            resolve_outbound_way(candidate).expect("loopback route should resolve locally");
         assert_eq!(resolved.2.src, "127.0.0.1:50000".parse().unwrap());
         assert_eq!(
             resolved.1.local(),
@@ -238,6 +266,11 @@ mod tests {
                 "inet://203.0.113.10:50000",
                 "203.0.113.10:50000",
                 "127.0.0.1:4433",
+            ),
+            way(
+                "inet://[::ffff:127.0.0.1]:50000",
+                "[::ffff:127.0.0.1]:50000",
+                "[::ffff:203.0.113.10]:4433",
             ),
         ] {
             assert_eq!(
@@ -324,6 +357,33 @@ mod tests {
                 "[fe80::2]:4433"
             )),
             Err(InvalidWay::LinkLocalScopeMismatch)
+        );
+        assert_eq!(
+            validate_way(&way(
+                "inet://[::]:50000",
+                "[fe80::1%3]:50000",
+                "[fe80::2]:4433"
+            )),
+            Err(InvalidWay::LinkLocalScopeMismatch)
+        );
+    }
+
+    #[test]
+    fn rejects_direct_endpoint_and_link_mismatches() {
+        let mut candidate = way(
+            "inet://127.0.0.1:50000",
+            "127.0.0.1:50000",
+            "127.0.0.1:4433",
+        );
+        candidate.1 = Pathway::new(
+            EndpointAddr::direct("127.0.0.1:50001".parse().unwrap()),
+            candidate.1.remote(),
+        );
+        assert_eq!(
+            validate_way(&candidate),
+            Err(InvalidWay::DirectEndpointMismatch {
+                side: EndpointSide::Local
+            })
         );
     }
 

--- a/qinterface/src/component/route/admissibility.rs
+++ b/qinterface/src/component/route/admissibility.rs
@@ -1,0 +1,292 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use qbase::net::Family;
+use thiserror::Error;
+
+use super::Way;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointSide {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum InvalidWay {
+    #[error("local and remote addresses use different IP families")]
+    AddressFamilyMismatch,
+    #[error("bind URI family does not match the concrete local address")]
+    BindFamilyMismatch,
+    #[error("loopback and non-loopback addresses cannot form one path")]
+    LoopbackScopeMismatch,
+    #[error("{side:?} concrete address is unspecified")]
+    Unspecified { side: EndpointSide },
+    #[error("{side:?} concrete endpoint uses port zero")]
+    ZeroPort { side: EndpointSide },
+    #[error("{side:?} concrete address is multicast")]
+    Multicast { side: EndpointSide },
+    #[error("{side:?} concrete address is broadcast")]
+    Broadcast { side: EndpointSide },
+    #[error("local and remote concrete endpoints are identical")]
+    IdenticalEndpoints,
+    #[error("link-local peer is missing a compatible interface scope")]
+    LinkLocalScopeMismatch,
+    #[error("bind URI cannot currently resolve to an interface")]
+    BindUnavailable,
+    #[error("concrete local address {local} does not match bind address {bound}")]
+    BindAddressMismatch {
+        bound: SocketAddr,
+        local: SocketAddr,
+    },
+}
+
+fn validate_endpoint(side: EndpointSide, addr: SocketAddr) -> Result<(), InvalidWay> {
+    if addr.ip().is_unspecified() {
+        return Err(InvalidWay::Unspecified { side });
+    }
+    if addr.port() == 0 {
+        return Err(InvalidWay::ZeroPort { side });
+    }
+    if addr.ip().is_multicast() {
+        return Err(InvalidWay::Multicast { side });
+    }
+    if matches!(addr.ip(), IpAddr::V4(ip) if ip == Ipv4Addr::BROADCAST) {
+        return Err(InvalidWay::Broadcast { side });
+    }
+    Ok(())
+}
+
+fn is_link_local(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_link_local(),
+        IpAddr::V6(ip) => ip.is_unicast_link_local(),
+    }
+}
+
+pub fn validate_way((bind, _pathway, link): &Way) -> Result<(), InvalidWay> {
+    let local = link.src;
+    let remote = link.dst;
+
+    if local.is_ipv4() != remote.is_ipv4() {
+        return Err(InvalidWay::AddressFamilyMismatch);
+    }
+    let link_family = if local.is_ipv4() {
+        Family::V4
+    } else {
+        Family::V6
+    };
+    if bind.family() != link_family {
+        return Err(InvalidWay::BindFamilyMismatch);
+    }
+    validate_endpoint(EndpointSide::Local, local)?;
+    validate_endpoint(EndpointSide::Remote, remote)?;
+    if local == remote {
+        return Err(InvalidWay::IdenticalEndpoints);
+    }
+    if local.ip().is_loopback() != remote.ip().is_loopback() {
+        return Err(InvalidWay::LoopbackScopeMismatch);
+    }
+
+    let binding = bind
+        .resolve_binding()
+        .map_err(|_| InvalidWay::BindUnavailable)?;
+    let bound = binding.addr;
+    if !bound.ip().is_unspecified() && bound.ip() != local.ip() {
+        return Err(InvalidWay::BindAddressMismatch { bound, local });
+    }
+
+    if is_link_local(remote.ip()) {
+        match binding.device {
+            Some(device) => {
+                if let SocketAddr::V6(remote) = remote
+                    && remote.scope_id() != 0
+                    && remote.scope_id() != device.index
+                {
+                    return Err(InvalidWay::LinkLocalScopeMismatch);
+                }
+            }
+            None => {
+                if !is_link_local(local.ip()) {
+                    return Err(InvalidWay::LinkLocalScopeMismatch);
+                }
+                if let (SocketAddr::V6(local), SocketAddr::V6(remote)) = (local, remote) {
+                    let local_scope = local.scope_id();
+                    let remote_scope = remote.scope_id();
+                    if (local_scope == 0 && remote_scope == 0)
+                        || (local_scope != 0 && remote_scope != 0 && local_scope != remote_scope)
+                    {
+                        return Err(InvalidWay::LinkLocalScopeMismatch);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use qbase::net::{
+        addr::EndpointAddr,
+        route::{Link, Pathway},
+    };
+
+    use super::*;
+    use crate::component::route::Way;
+
+    fn way(bind: &str, local: &str, remote: &str) -> Way {
+        let local: SocketAddr = local.parse().unwrap();
+        let remote: SocketAddr = remote.parse().unwrap();
+        (
+            bind.parse().unwrap(),
+            Pathway::new(EndpointAddr::direct(local), EndpointAddr::direct(remote)),
+            Link::new(local, remote),
+        )
+    }
+
+    #[test]
+    fn accepts_safe_unicast_combinations() {
+        for candidate in [
+            way(
+                "inet://127.0.0.1:50000",
+                "127.0.0.1:50000",
+                "127.0.0.1:4433",
+            ),
+            way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "203.0.113.10:4433",
+            ),
+            way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "192.168.1.10:4433",
+            ),
+            way(
+                "inet://[2001:db8::1]:50000",
+                "[2001:db8::1]:50000",
+                "[2001:db8::2]:4433",
+            ),
+        ] {
+            assert_eq!(validate_way(&candidate), Ok(()), "{candidate:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_loopback_scope_mismatch_in_both_directions() {
+        for candidate in [
+            way(
+                "inet://127.0.0.1:50000",
+                "127.0.0.1:50000",
+                "203.0.113.10:4433",
+            ),
+            way(
+                "inet://203.0.113.10:50000",
+                "203.0.113.10:50000",
+                "127.0.0.1:4433",
+            ),
+        ] {
+            assert_eq!(
+                validate_way(&candidate),
+                Err(InvalidWay::LoopbackScopeMismatch)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_path_endpoints() {
+        assert!(matches!(
+            validate_way(&way(
+                "inet://0.0.0.0:50000",
+                "0.0.0.0:50000",
+                "203.0.113.10:4433"
+            )),
+            Err(InvalidWay::Unspecified {
+                side: EndpointSide::Local
+            })
+        ));
+        assert!(matches!(
+            validate_way(&way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "224.0.0.1:4433"
+            )),
+            Err(InvalidWay::Multicast {
+                side: EndpointSide::Remote
+            })
+        ));
+        assert!(matches!(
+            validate_way(&way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "255.255.255.255:4433"
+            )),
+            Err(InvalidWay::Broadcast {
+                side: EndpointSide::Remote
+            })
+        ));
+        assert!(matches!(
+            validate_way(&way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "203.0.113.10:0"
+            )),
+            Err(InvalidWay::ZeroPort {
+                side: EndpointSide::Remote
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_family_identity_bind_and_link_local_scope_mismatches() {
+        assert_eq!(
+            validate_way(&way(
+                "inet://192.168.1.10:50000",
+                "192.168.1.10:50000",
+                "[2001:db8::2]:4433"
+            )),
+            Err(InvalidWay::AddressFamilyMismatch)
+        );
+        assert_eq!(
+            validate_way(&way(
+                "inet://192.168.1.10:4433",
+                "192.168.1.10:4433",
+                "192.168.1.10:4433"
+            )),
+            Err(InvalidWay::IdenticalEndpoints)
+        );
+        assert!(matches!(
+            validate_way(&way(
+                "inet://192.168.1.11:50000",
+                "192.168.1.10:50000",
+                "203.0.113.10:4433"
+            )),
+            Err(InvalidWay::BindAddressMismatch { .. })
+        ));
+        assert_eq!(
+            validate_way(&way(
+                "inet://[2001:db8::1]:50000",
+                "[2001:db8::1]:50000",
+                "[fe80::2]:4433"
+            )),
+            Err(InvalidWay::LinkLocalScopeMismatch)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn iface_bind_rejects_an_address_not_owned_by_that_device() {
+        let candidate = way(
+            "iface://v4.lo:50000",
+            "203.0.113.10:50000",
+            "198.51.100.10:4433",
+        );
+        assert!(matches!(
+            validate_way(&candidate),
+            Err(InvalidWay::BindAddressMismatch { .. })
+        ));
+    }
+}

--- a/qinterface/src/io/handy.rs
+++ b/qinterface/src/io/handy.rs
@@ -13,7 +13,7 @@ pub mod qudp {
 
     use bytes::BytesMut;
     use qbase::{
-        net::route::{Line, Link, Pathway},
+        net::route::{Line, Pathway},
         util::Wakers,
     };
     use qudp::BATCH_SIZE;
@@ -130,7 +130,6 @@ pub mod qudp {
         ) -> Poll<io::Result<usize>> {
             let io = self.usc()?;
             self.recv_wakers.combine_with(cx, |cx| {
-                let dst = io.local_addr()?;
                 let len = route.len().min(pkts.len());
                 let mut rcvd_lines = Vec::with_capacity(len);
                 rcvd_lines.resize_with(route.len(), Line::default);
@@ -142,9 +141,10 @@ pub mod qudp {
                 let nrcvd = ready!(io.poll_recv(cx, &mut bufs, &mut rcvd_lines))?;
 
                 for (idx, mut line) in rcvd_lines.into_iter().take(nrcvd).enumerate() {
-                    let pathway = Pathway::new(line.link.src.into(), dst.into());
-                    line.link = Link::new(line.src, io.local_addr()?).flip();
-                    route[idx] = Route::new(pathway.flip(), line);
+                    let link = line.link.flip();
+                    let pathway = Pathway::from(link);
+                    line.link = link;
+                    route[idx] = Route::new(pathway, line);
                 }
 
                 Poll::Ready(Ok(nrcvd))
@@ -157,6 +157,42 @@ pub mod qudp {
             self.recv_wakers.wake_all();
             self.io = Ok(Err(Closed(())));
             Poll::Ready(Ok(()))
+        }
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    mod tests {
+        use std::net::Ipv4Addr;
+
+        use super::*;
+        use crate::io::IoExt as _;
+
+        #[tokio::test]
+        async fn wildcard_receive_preserves_packet_destination() {
+            let controller =
+                UdpSocketController::bind("inet://0.0.0.0:0".parse().expect("bind URI"));
+            let mut destination = controller.bound_addr().expect("bound address");
+            destination.set_ip(Ipv4Addr::LOCALHOST.into());
+
+            let sender = std::net::UdpSocket::bind("127.0.0.1:0").expect("sender socket");
+            let sender_addr = sender.local_addr().expect("sender address");
+            sender
+                .send_to(b"route", destination)
+                .expect("send datagram");
+
+            let mut bufs = Vec::new();
+            let mut routes = Vec::new();
+            let (_, route) = controller
+                .recvmmsg(&mut bufs, &mut routes)
+                .await
+                .expect("receive datagram")
+                .next()
+                .expect("one datagram");
+
+            assert_eq!(route.line.link.src, destination);
+            assert_eq!(route.line.link.dst, sender_addr);
+            assert_eq!(route.pathway.local().addr(), destination);
+            assert_eq!(route.pathway.remote().addr(), sender_addr);
         }
     }
 }

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -33,7 +33,7 @@ use qinterface::{
     bind_uri::BindUri,
     component::{
         local_endpoint::InterfaceEndpointKey,
-        route::{InvalidWay, QuicRouter, QuicRouterComponent, Way, validate_way},
+        route::{InvalidWay, QuicRouter, QuicRouterComponent, Way, resolve_way, validate_way},
     },
     io::{IO, IoExt, ProductIO},
     manager::InterfaceManager,
@@ -96,7 +96,7 @@ fn build_validated_way(
 ) -> Result<(BindUri, Link, PathWay), InvalidWay> {
     let link = Link::new(local_addr, remote_addr);
     let pathway = PathWay::new(local, remote);
-    let way = (bind.clone(), pathway, link);
+    let way = resolve_way((bind.clone(), pathway, link))?;
     validate_way(&way)?;
     Ok((way.0, way.2, way.1))
 }

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -16,7 +16,7 @@ use qbase::{
         io::{ReceiveFrame, SendFrame},
     },
     net::{
-        AddrFamily, NatType,
+        NatType,
         addr::EndpointAddr,
         route::{Line, Link, Route},
         tx::Signals,
@@ -33,7 +33,7 @@ use qinterface::{
     bind_uri::BindUri,
     component::{
         local_endpoint::InterfaceEndpointKey,
-        route::{QuicRouter, QuicRouterComponent, Way},
+        route::{InvalidWay, QuicRouter, QuicRouterComponent, Way, validate_way},
     },
     io::{IO, IoExt, ProductIO},
     manager::InterfaceManager,
@@ -62,6 +62,43 @@ fn interface_endpoint_key(endpoint: EndpointAddr) -> InterfaceEndpointKey {
         EndpointAddr::Direct { .. } => InterfaceEndpointKey::Direct,
         EndpointAddr::Agent { agent, .. } => InterfaceEndpointKey::Agent(agent),
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ResolvePathError {
+    #[error(transparent)]
+    InvalidWay(#[from] InvalidWay),
+    #[error("bind URI does not match resolver source constraint")]
+    SourceConstraint,
+    #[error("unsupported endpoint type combination for punching")]
+    UnsupportedEndpointPair,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+fn validate_endpoint_pair(
+    local: EndpointAddr,
+    remote: EndpointAddr,
+) -> Result<(), ResolvePathError> {
+    match (local, remote) {
+        (EndpointAddr::Direct { .. }, EndpointAddr::Direct { .. })
+        | (EndpointAddr::Agent { .. }, EndpointAddr::Agent { .. }) => Ok(()),
+        _ => Err(ResolvePathError::UnsupportedEndpointPair),
+    }
+}
+
+fn build_validated_way(
+    bind: &BindUri,
+    local: EndpointAddr,
+    remote: EndpointAddr,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+) -> Result<(BindUri, Link, PathWay), InvalidWay> {
+    let link = Link::new(local_addr, remote_addr);
+    let pathway = PathWay::new(local, remote);
+    let way = (bind.clone(), pathway, link);
+    validate_way(&way)?;
+    Ok((way.0, way.2, way.1))
 }
 
 #[allow(dead_code)]
@@ -613,11 +650,28 @@ where
         let changes = remote_endpoints
             .into_iter()
             .filter_map(|(remote_endpoint, source)| {
-                self.resolve_punch_connection(&bind_uri, &local_endpoint, &remote_endpoint, &source)
-                    .ok()
-                    .map(|(bind_uri, link, pathway)| {
-                        LocalEndpointPathChange::AddPath((bind_uri, pathway, link))
-                    })
+                match self.resolve_punch_connection(
+                    &bind_uri,
+                    &local_endpoint,
+                    &remote_endpoint,
+                    &source,
+                ) {
+                    Ok((bind_uri, link, pathway)) => {
+                        Some(LocalEndpointPathChange::AddPath((bind_uri, pathway, link)))
+                    }
+                    Err(error) => {
+                        tracing::trace!(
+                            target: "dquic",
+                            %bind_uri,
+                            %local_endpoint,
+                            %remote_endpoint,
+                            ?source,
+                            %error,
+                            "skipping incompatible peer endpoint candidate"
+                        );
+                        None
+                    }
+                }
             })
             .collect();
         LocalEndpointPathChanges::new(changes)
@@ -857,8 +911,19 @@ where
         };
         let mut ways = Vec::new();
         for (bind, local_ep) in local_endpoints {
-            if let Ok(way) = self.resolve_punch_connection(&bind, &local_ep, &endpoint, &source) {
-                ways.push(way);
+            match self.resolve_punch_connection(&bind, &local_ep, &endpoint, &source) {
+                Ok(way) => ways.push(way),
+                Err(error) => {
+                    tracing::trace!(
+                        target: "dquic",
+                        %bind,
+                        %local_ep,
+                        remote_endpoint = %endpoint,
+                        ?source,
+                        %error,
+                        "skipping incompatible peer endpoint candidate"
+                    );
+                }
             }
         }
         Ok(ways)
@@ -1590,33 +1655,25 @@ where
         local: &EndpointAddr,
         remote: &EndpointAddr,
         source: &qresolve::Source,
-    ) -> io::Result<(BindUri, Link, PathWay)> {
+    ) -> Result<(BindUri, Link, PathWay), ResolvePathError> {
         if let qresolve::Source::Mdns { nic, family } = source {
             let matches_iface = bind
                 .as_iface_bind_uri()
                 .is_some_and(|(lf, ln, _)| lf == *family && ln == nic.as_ref());
             if !matches_iface {
-                return Err(io::Error::other(
-                    "Bind URI does not match source constraint",
-                ));
+                return Err(ResolvePathError::SourceConstraint);
             }
         }
-        if local == remote {
-            return Err(io::Error::other("Local and remote endpoints are identical"));
-        }
+        validate_endpoint_pair(*local, *remote)?;
 
         let (local_addr, remote_addr) = self.extract_addresses(bind, local, remote)?;
-
-        if local_addr.family() != remote_addr.family() {
-            return Err(io::Error::other(
-                "Local and remote addresses must be in the same address family",
-            ));
-        }
-
-        let link = Link::new(local_addr, remote_addr);
-        let pathway = PathWay::new(*local, *remote);
-
-        Ok((bind.clone(), link, pathway))
+        Ok(build_validated_way(
+            bind,
+            *local,
+            *remote,
+            local_addr,
+            remote_addr,
+        )?)
     }
 
     fn extract_addresses(
@@ -1639,9 +1696,7 @@ where
                 })?;
                 Ok((iface.bound_addr()?, *agent))
             }
-            _ => Err(io::Error::other(
-                "Unsupported endpoint type combination for punching",
-            )),
+            _ => unreachable!("endpoint kinds were validated before address extraction"),
         }
     }
 }
@@ -1788,6 +1843,49 @@ async fn dynamic_iface(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn direct_pairing_rejects_loopback_to_non_loopback() {
+        let bind: BindUri = "inet://127.0.0.1:50000".parse().unwrap();
+        let local_addr: SocketAddr = "127.0.0.1:50000".parse().unwrap();
+        let remote_addr: SocketAddr = "203.0.113.10:4433".parse().unwrap();
+        let local = EndpointAddr::direct(local_addr);
+        let remote = EndpointAddr::direct(remote_addr);
+
+        let error = build_validated_way(&bind, local, remote, local_addr, remote_addr)
+            .expect_err("mixed loopback scope must be rejected");
+        assert_eq!(
+            error,
+            qinterface::component::route::InvalidWay::LoopbackScopeMismatch
+        );
+    }
+
+    #[test]
+    fn direct_pairing_accepts_loopback_to_loopback() {
+        let bind: BindUri = "inet://127.0.0.1:50000".parse().unwrap();
+        let local_addr: SocketAddr = "127.0.0.1:50000".parse().unwrap();
+        let remote_addr: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+        let local = EndpointAddr::direct(local_addr);
+        let remote = EndpointAddr::direct(remote_addr);
+
+        let (_, link, pathway) = build_validated_way(&bind, local, remote, local_addr, remote_addr)
+            .expect("matching loopback scope must be retained");
+        assert_eq!(link, Link::new(local_addr, remote_addr));
+        assert_eq!(pathway, PathWay::new(local, remote));
+    }
+
+    #[test]
+    fn mixed_direct_agent_pair_is_rejected() {
+        let direct = EndpointAddr::direct("127.0.0.1:50000".parse().unwrap());
+        let agent = EndpointAddr::with_agent(
+            "127.0.0.1:20004".parse().unwrap(),
+            "198.51.100.10:40000".parse().unwrap(),
+        );
+        assert!(matches!(
+            validate_endpoint_pair(direct, agent),
+            Err(ResolvePathError::UnsupportedEndpointPair)
+        ));
+    }
 
     fn bind_uri() -> BindUri {
         "inet://127.0.0.1:0".parse().expect("valid bind uri")

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -33,9 +33,7 @@ use qinterface::{
     bind_uri::BindUri,
     component::{
         local_endpoint::InterfaceEndpointKey,
-        route::{
-            InvalidWay, QuicRouter, QuicRouterComponent, Way, resolve_outbound_way, validate_way,
-        },
+        route::{InvalidWay, QuicRouter, QuicRouterComponent, Way, validate_outbound_candidate},
     },
     io::{IO, IoExt, ProductIO},
     manager::InterfaceManager,
@@ -98,8 +96,8 @@ fn build_validated_way(
 ) -> Result<(BindUri, Link, PathWay), InvalidWay> {
     let link = Link::new(local_addr, remote_addr);
     let pathway = PathWay::new(local, remote);
-    let way = resolve_outbound_way((bind.clone(), pathway, link))?;
-    validate_way(&way)?;
+    let way = (bind.clone(), pathway, link);
+    validate_outbound_candidate(&way)?;
     Ok((way.0, way.2, way.1))
 }
 
@@ -1872,6 +1870,21 @@ mod tests {
 
         let (_, link, pathway) = build_validated_way(&bind, local, remote, local_addr, remote_addr)
             .expect("matching loopback scope must be retained");
+        assert_eq!(link, Link::new(local_addr, remote_addr));
+        assert_eq!(pathway, PathWay::new(local, remote));
+    }
+
+    #[test]
+    fn direct_pairing_preserves_a_wildcard_local_link() {
+        let bind: BindUri = "inet://0.0.0.0:50000".parse().unwrap();
+        let local_addr: SocketAddr = "0.0.0.0:50000".parse().unwrap();
+        let remote_addr: SocketAddr = "203.0.113.10:4433".parse().unwrap();
+        let local = EndpointAddr::direct("192.0.2.10:50000".parse().unwrap());
+        let remote = EndpointAddr::direct(remote_addr);
+
+        let (_, link, pathway) = build_validated_way(&bind, local, remote, local_addr, remote_addr)
+            .expect("wildcard source selection belongs to IO");
+
         assert_eq!(link, Link::new(local_addr, remote_addr));
         assert_eq!(pathway, PathWay::new(local, remote));
     }

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -33,7 +33,9 @@ use qinterface::{
     bind_uri::BindUri,
     component::{
         local_endpoint::InterfaceEndpointKey,
-        route::{InvalidWay, QuicRouter, QuicRouterComponent, Way, resolve_way, validate_way},
+        route::{
+            InvalidWay, QuicRouter, QuicRouterComponent, Way, resolve_outbound_way, validate_way,
+        },
     },
     io::{IO, IoExt, ProductIO},
     manager::InterfaceManager,
@@ -96,7 +98,7 @@ fn build_validated_way(
 ) -> Result<(BindUri, Link, PathWay), InvalidWay> {
     let link = Link::new(local_addr, remote_addr);
     let pathway = PathWay::new(local, remote);
-    let way = resolve_way((bind.clone(), pathway, link))?;
+    let way = resolve_outbound_way((bind.clone(), pathway, link))?;
     validate_way(&way)?;
     Ok((way.0, way.2, way.1))
 }

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qudp"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 edition.workspace = true
 description = "High-performance UDP encapsulation for QUIC"
 readme.workspace = true

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qudp"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 description = "High-performance UDP encapsulation for QUIC"
 readme.workspace = true

--- a/qudp/src/unix.rs
+++ b/qudp/src/unix.rs
@@ -416,6 +416,11 @@ fn parse_cmsg(cmsg: ControlMessageOwned, line: &mut Line) {
         ControlMessageOwned::Ipv6PacketInfo(pktinfo6) => {
             let ip = IpAddr::V6(Ipv6Addr::from(pktinfo6.ipi6_addr.s6_addr));
             line.link.dst.set_ip(ip);
+            if let SocketAddr::V6(dst) = &mut line.link.dst
+                && dst.ip().is_unicast_link_local()
+            {
+                dst.set_scope_id(pktinfo6.ipi6_ifindex);
+            }
         }
         _ => {}
     }
@@ -445,5 +450,30 @@ impl ToSocketAddr for SockaddrStorage {
             }
             _ => panic!("Unsupported address family"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv6_link_local_packet_info_preserves_the_interface_scope() {
+        let mut line = Line::default();
+        let address = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let packet_info = libc::in6_pktinfo {
+            ipi6_addr: libc::in6_addr {
+                s6_addr: address.octets(),
+            },
+            ipi6_ifindex: 7,
+        };
+
+        parse_cmsg(ControlMessageOwned::Ipv6PacketInfo(packet_info), &mut line);
+
+        let SocketAddr::V6(destination) = line.link.dst else {
+            panic!("IPv6 packet info must produce an IPv6 destination");
+        };
+        assert_eq!(*destination.ip(), address);
+        assert_eq!(destination.scope_id(), 7);
     }
 }


### PR DESCRIPTION
## Summary

- validate concrete QUIC paths before connection/path creation or connectless ODCID registration
- preserve received destination and IPv6 link-local scope evidence instead of inferring or rewriting it
- keep outbound wildcard source selection owned by the selected IO
- reject inadmissible traversal pairs and report only accepted direct paths
- advance every changed publish surface and its dependency contract

## Release plan

| Package | Previous | Candidate | Reason |
| --- | --- | --- | --- |
| `qudp` | `0.6.0` | `0.7.0-beta.1` | IPv6 link-local receive scope fix; keep this transport wave on a beta line |
| `qinterface` | `0.7.0-beta.1` | `0.7.0-beta.2` | path validation and receive-evidence fixes |
| `qtraversal` | `0.7.0-beta.3` | `0.7.0-beta.4` | admissible-pair selection fixes |
| `qconnection` | `0.7.0-beta.2` | `0.8.0-beta.1` | new exhaustive `CreatePathFailure::InvalidWay` variant is semver-breaking |
| `dquic` | `0.7.0-beta.3` | `0.7.0-beta.4` | umbrella transport fixes and updated dependency graph |

- Surface: crates.io, incremental releases
- Planned repository tag: `v0.7.0-beta.4`
- Publish order: `qudp` → `qinterface` → `qtraversal` → `qconnection` → `dquic`
- `h3-shim` remains excluded from release surfaces by policy

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --all-targets --all-features -- -Dwarnings`
- `cargo +nightly test --workspace --all-features --all-targets -- --test-threads=1`
- `cargo-semver-checks` for all five changed library crates
  - patch checks passed for `qinterface`, `qtraversal`, and `dquic`
  - `qudp` moves from `0.6.0` to the beta line `0.7.0-beta.1`; its major-line semver check passed
  - the provisional `qconnection 0.7.0-beta.3` patch check correctly detected the added exhaustive enum variant; candidate changed to `0.8.0-beta.1`, then the major-line check passed
- `cargo +stable publish --dry-run --locked -p qudp -p qinterface -p qtraversal -p qconnection -p dquic`

