### PR TITLE
fix(qcongestion): gate loss detection on ack

### DIFF
--- a/qcongestion/src/congestion.rs
+++ b/qcongestion/src/congestion.rs
@@ -110,12 +110,11 @@ impl CongestionController {
                     self.need_send_ack_eliciting_packets[epoch].saturating_sub(1);
             }
             self.algorithm.on_packet_sent_cc(&sent);
-            self.packet_spaces[epoch]
-                .loss_time
-                .get_or_insert_with(|| now + self.rtt.loss_delay());
-            self.set_loss_detection_timer();
         }
         self.packet_spaces[epoch].sent_packets.push_back(sent);
+        if in_flight {
+            self.set_loss_detection_timer();
+        }
         self.pacer.on_sent(sent_bytes);
     }
 
@@ -606,4 +605,46 @@ impl super::Transport for ArcCC {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use std::sync::{Arc, atomic::AtomicU16};
+
+    use qbase::net::tx::ArcSendWaker;
+
+    use super::*;
+    use crate::HandshakeStatus;
+
+    struct NoopFeedback;
+
+    impl Feedback for NoopFeedback {
+        fn may_loss(&self, _trigger: PacketLostTrigger, _pns: &mut dyn Iterator<Item = u64>) {}
+    }
+
+    fn controller() -> CongestionController {
+        let feedback: Arc<dyn Feedback> = Arc::new(NoopFeedback);
+        let handshake = Arc::new(HandshakeStatus::new(false));
+        handshake.handshake_confirmed();
+        let path_status = PathStatus::new(handshake, Arc::new(AtomicU16::new(MSS as u16)));
+        path_status.release_anti_amplification_limit();
+
+        CongestionController::init(
+            Algorithm::NewReno,
+            Duration::from_millis(25),
+            [feedback.clone(), feedback.clone(), feedback],
+            path_status,
+            ArcSendWaker::new(),
+        )
+    }
+
+    #[test]
+    fn sending_without_ack_arms_pto_not_loss_timer() {
+        let mut controller = controller();
+
+        controller.on_packet_sent(0, Epoch::Data, true, true, MSS);
+
+        let space = &controller.packet_spaces[Epoch::Data];
+        let last_sent = space.time_of_last_ack_eliciting_packet.unwrap();
+        let pto = controller.get_pto(Epoch::Data);
+        assert_eq!(space.loss_time, None);
+        assert_eq!(controller.loss_detection_timer, Some(last_sent + pto));
+    }
+}

--- a/qcongestion/src/packets.rs
+++ b/qcongestion/src/packets.rs
@@ -145,7 +145,6 @@ pub(crate) struct PacketSpace {
     pub(crate) loss_time: Option<Instant>,
     pub(crate) sent_packets: VecDeque<SentPacket>,
     pub(crate) rcvd_packets: RcvdRecords,
-    pub(crate) max_ack_delay: Duration,
 }
 
 pub(crate) struct NewlyAckedPackets {
@@ -161,7 +160,6 @@ impl PacketSpace {
             loss_time: None,
             sent_packets: VecDeque::with_capacity(4),
             rcvd_packets: RcvdRecords::new(epoch, max_ack_delay),
-            max_ack_delay,
         }
     }
 
@@ -234,24 +232,26 @@ impl PacketSpace {
         packet_threshold: usize,
         algorithm: &mut Box<dyn Control>,
     ) -> impl Iterator<Item = u64> + use<> {
-        // assert!(self.largest_acked_packet.is_some());
         self.loss_time = None;
+        let Some(largest_acked) = self.largest_acked_packet else {
+            return Vec::new().into_iter();
+        };
 
         let now = Instant::now();
-        let lost_sent_time = now - loss_delay - self.max_ack_delay;
-        let largest_acked = self.largest_acked_packet.unwrap_or(0);
-        let largest_index = self
-            .sent_packets
-            .binary_search_by(|p| p.packet_number.cmp(&largest_acked))
-            .unwrap_or_else(|i| i.saturating_sub(1));
+        let lost_sent_time = now - loss_delay;
 
         let loss: Vec<_> = self
             .sent_packets
             .iter_mut()
             .enumerate()
-            .filter(|(_, pkt)| pkt.state == State::Inflight)
+            .filter(|(_, pkt)| pkt.state == State::Inflight && pkt.packet_number <= largest_acked)
             .map(move |(idx, unacked)| {
-                if unacked.time_sent < lost_sent_time || largest_index >= idx + packet_threshold {
+                if unacked.time_sent <= lost_sent_time
+                    || largest_acked
+                        >= unacked
+                            .packet_number
+                            .saturating_add(packet_threshold as u64)
+                {
                     unacked.state = State::Retransmitted;
                     Ok((idx, &*unacked))
                 } else {
@@ -314,6 +314,10 @@ mod tests {
     use super::*;
     use crate::algorithm::new_reno::NewReno;
 
+    fn new_reno() -> Box<dyn Control> {
+        Box::new(NewReno::new(Arc::new(AtomicU16::new(1200))))
+    }
+
     #[test]
     fn test_packet_space() {
         let mut packet_space = PacketSpace::with_epoch(Epoch::Initial, Duration::from_millis(100));
@@ -338,7 +342,7 @@ mod tests {
             None,
         );
 
-        let mut reno: Box<dyn Control> = Box::new(NewReno::new(Arc::new(AtomicU16::new(1200))));
+        let mut reno = new_reno();
         packet_space.on_ack_rcvd(&ack_frame, &mut reno);
         // init 12000, ack 8 packet 12000 + 8 * MSS = 21600
         assert_eq!(reno.congestion_window(), 21600);
@@ -384,6 +388,79 @@ mod tests {
         let loss = packet_space.detect_lost_packets(Duration::from_millis(100), 3, &mut reno);
         assert_eq!(loss.collect::<Vec<_>>(), vec![10, 11, 12, 14]);
         assert_eq!(reno.congestion_window(), (20817 - 1200) / 2);
+    }
+
+    #[test]
+    fn does_not_detect_loss_before_any_ack() {
+        let mut packet_space = PacketSpace::with_epoch(Epoch::Data, Duration::from_millis(25));
+        packet_space.sent_packets.push_back(SentPacket::new(
+            0,
+            Instant::now() - Duration::from_secs(1),
+            true,
+            true,
+            1200,
+        ));
+        let mut reno = new_reno();
+
+        let lost = packet_space
+            .detect_lost_packets(Duration::from_millis(10), 3, &mut reno)
+            .collect::<Vec<_>>();
+
+        assert!(lost.is_empty());
+        assert_eq!(packet_space.loss_time, None);
+        assert_eq!(packet_space.sent_packets[0].state, State::Inflight);
+    }
+
+    #[test]
+    fn only_detects_packets_sent_before_largest_ack() {
+        let mut packet_space = PacketSpace::with_epoch(Epoch::Data, Duration::from_millis(25));
+        let now = Instant::now();
+        packet_space.sent_packets.push_back(SentPacket::new(
+            10,
+            now - Duration::from_secs(3),
+            true,
+            true,
+            1200,
+        ));
+        let mut acknowledged = SentPacket::new(100, now - Duration::from_secs(2), true, true, 1200);
+        acknowledged.state = State::Acked;
+        packet_space.sent_packets.push_back(acknowledged);
+        packet_space.sent_packets.push_back(SentPacket::new(
+            101,
+            now - Duration::from_secs(1),
+            true,
+            true,
+            1200,
+        ));
+        packet_space.largest_acked_packet = Some(100);
+        let mut reno = new_reno();
+
+        let lost = packet_space
+            .detect_lost_packets(Duration::from_millis(500), 3, &mut reno)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lost, vec![10]);
+        assert_eq!(packet_space.sent_packets[2].state, State::Inflight);
+    }
+
+    #[test]
+    fn packet_threshold_uses_packet_numbers_not_queue_indexes() {
+        let mut packet_space = PacketSpace::with_epoch(Epoch::Data, Duration::from_millis(25));
+        let now = Instant::now();
+        packet_space
+            .sent_packets
+            .push_back(SentPacket::new(10, now, true, true, 1200));
+        let mut acknowledged = SentPacket::new(100, now, true, true, 1200);
+        acknowledged.state = State::Acked;
+        packet_space.sent_packets.push_back(acknowledged);
+        packet_space.largest_acked_packet = Some(100);
+        let mut reno = new_reno();
+
+        let lost = packet_space
+            .detect_lost_packets(Duration::from_secs(1), 3, &mut reno)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lost, vec![10]);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
原来的逻辑：
当服务端发送 ACK-eliciting 数据，而客户端未返回 ACK 时：
1. 每次发包都会预设一个 time-threshold loss_time。
2. 时器到期后，即使该 packet number space 从未收到 ACK，也会把包判定为丢失。

会导致绕过 PTO 指数退避重发包，可能导致 ddns 服务器少量首包引发大量发包的现象
与 [RFC 9002 6.1](https://datatracker.ietf.org/doc/html/rfc9002#section-6.1) 要求 time-threshold 和 packet-threshold 丢包判断必须基于 ACK 不符

修复
1. 将新包加入发送队列后再计算定时器，确保首次发包能够正确启动 PTO。
2. 没有 largest_acked_packet 时直接跳过丢包检测。