### PR TITLE
fix(qconnection): enforce anti-amplification credit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ log
 
 # Local agent instructions
 AGENTS.md
+
+# Local design notes
+/design/

--- a/dquic/src/common.rs
+++ b/dquic/src/common.rs
@@ -71,7 +71,7 @@ impl Network {
                     let stun_router = components
                         .init_with(|| StunRouterComponent::new(iface.downgrade()))
                         .router();
-                    // initial stun clients (DNS 解析推迟到后台 lookup 任务)
+                    // initial stun clients (DNS is resolved once by a background task)
                     let stun_server = stun_server.clone();
                     let clients = components
                         .init_with(|| {
@@ -131,9 +131,8 @@ impl Network {
             self.stun_server.clone()
         };
 
-        // STUN agent 的 DNS 解析推迟到 StunClientsComponent 的后台任务（它会在
-        // clients < MIN_AGENTS 时自动触发 lookup，且自带超时保护）。bind 自身
-        // 不再在关键路径上等待 DNS，避免 resolver 挂起导致整个绑定流程锁死。
+        // STUN agent DNS resolution runs once in StunClientsComponent's background task.
+        // Binding itself never waits for DNS.
 
         let factory = self.iface_factory.clone();
         let bind_iface = self.iface_manager.bind(bind_uri, factory).await;

--- a/qbase/src/util/bound_queue.rs
+++ b/qbase/src/util/bound_queue.rs
@@ -8,7 +8,7 @@ use futures::{SinkExt, StreamExt, channel::mpsc};
 
 #[derive(Debug)]
 struct BoundQueueInner<T> {
-    tx: mpsc::Sender<T>,
+    tx: Mutex<mpsc::Sender<T>>,
     rx: Mutex<mpsc::Receiver<T>>,
 }
 
@@ -25,17 +25,21 @@ impl<T> BoundQueue<T> {
     #[inline]
     pub fn new(size: usize) -> Self {
         let (tx, rx) = mpsc::channel(size);
-        Self(Arc::new(BoundQueueInner { tx, rx: rx.into() }))
+        Self(Arc::new(BoundQueueInner {
+            tx: tx.into(),
+            rx: rx.into(),
+        }))
     }
 
     #[inline]
     pub fn try_send(&self, item: T) -> Result<(), mpsc::TrySendError<T>> {
-        self.0.tx.clone().try_send(item)
+        self.0.tx.lock().unwrap().try_send(item)
     }
 
     #[inline]
     pub async fn send(&self, item: T) -> Result<(), mpsc::SendError> {
-        self.0.tx.clone().send(item).await
+        let mut tx = self.0.tx.lock().unwrap().clone();
+        tx.send(item).await
     }
 
     #[inline]
@@ -45,12 +49,12 @@ impl<T> BoundQueue<T> {
 
     #[inline]
     pub fn close(&self) {
-        self.0.tx.clone().close_channel();
+        self.0.tx.lock().unwrap().close_channel();
     }
 
     #[inline]
     pub fn is_closed(&self) -> bool {
-        self.0.tx.is_closed()
+        self.0.tx.lock().unwrap().is_closed()
     }
 
     #[inline]
@@ -81,5 +85,20 @@ mod tests {
 
         assert_eq!(queue.recv().await, Some(1));
         assert_eq!(queue.recv().await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn try_send_remains_bounded() {
+        let queue = BoundQueue::new(2);
+
+        assert!(queue.try_send(1).is_ok());
+        assert!(queue.try_send(2).is_ok());
+        // futures gives each persistent sender one guaranteed slot in addition to the buffer.
+        assert!(queue.try_send(3).is_ok());
+        assert!(queue.try_send(4).is_err_and(|error| error.is_full()));
+
+        assert_eq!(queue.recv().await, Some(1));
+        assert_eq!(queue.recv().await, Some(2));
+        assert_eq!(queue.recv().await, Some(3));
     }
 }

--- a/qconnection/src/path/aa.rs
+++ b/qconnection/src/path/aa.rs
@@ -31,11 +31,16 @@ impl<const N: usize> AntiAmplifier<N> {
     }
 
     /// Store N * amount of credit
+    #[allow(deprecated)] // `try_update` is not available on the crate's MSRV.
     pub fn on_rcvd(&self, amount: usize) {
         if self.state.load(Ordering::Acquire) != Self::NORMAL {
             return;
         }
-        self.credit.fetch_add(amount * N, Ordering::AcqRel);
+        _ = self
+            .credit
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |credit| {
+                Some(credit.saturating_add(amount.saturating_mul(N)))
+            });
         self.tx_waker.wake_by(Signals::CREDIT);
     }
 
@@ -68,9 +73,14 @@ impl<const N: usize> AntiAmplifier<N> {
         }
     }
 
+    #[allow(deprecated)] // `try_update` is not available on the crate's MSRV.
     pub fn on_sent(&self, amount: usize) {
         if self.state.load(Ordering::Acquire) == Self::NORMAL {
-            self.credit.fetch_sub(amount, Ordering::AcqRel);
+            _ = self
+                .credit
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |credit| {
+                    Some(credit.saturating_sub(amount))
+                });
         }
     }
 
@@ -149,5 +159,25 @@ mod tests {
         // Post sent 5 units, should reduce credit by 5
         anti_amplifier.on_sent(5);
         assert_eq!(anti_amplifier.credit.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn sent_amount_larger_than_credit_does_not_underflow() {
+        let anti_amplifier = AntiAmplifier::<3>::new(ArcSendWaker::new());
+        anti_amplifier.on_rcvd(1);
+
+        anti_amplifier.on_sent(4);
+
+        assert_eq!(anti_amplifier.credit.load(Ordering::Acquire), 0);
+        assert_eq!(anti_amplifier.balance(), Err(Signals::CREDIT));
+    }
+
+    #[test]
+    fn received_credit_saturates_instead_of_wrapping() {
+        let anti_amplifier = AntiAmplifier::<3>::new(ArcSendWaker::new());
+
+        anti_amplifier.on_rcvd(usize::MAX);
+
+        assert_eq!(anti_amplifier.credit.load(Ordering::Acquire), usize::MAX);
     }
 }

--- a/qconnection/src/path/burst.rs
+++ b/qconnection/src/path/burst.rs
@@ -70,6 +70,18 @@ pub struct Burst {
     tls_handshake: ArcTlsHandshake,
 }
 
+fn datagram_capacity(
+    max_segment_size: usize,
+    mtu: usize,
+    forward_header_size: usize,
+    remaining_credit: usize,
+) -> Result<usize, Signals> {
+    let capacity = max_segment_size.min(mtu).min(remaining_credit);
+    (capacity > forward_header_size)
+        .then_some(capacity)
+        .ok_or(Signals::CREDIT)
+}
+
 impl super::Path {
     pub fn new_burst(self: &Arc<Self>, components: &Components) -> Burst {
         Burst {
@@ -526,6 +538,9 @@ impl Burst {
 
         let reversed_size = ForwardHeader::encoding_size(&self.path.pathway);
         let mut segment_lengths = Vec::with_capacity(max_segments);
+        let Some(mut remaining_credit) = self.path.anti_amplifier.balance()? else {
+            return Err(BurstError::PathDeactived);
+        };
 
         for segment_index in 0..max_segments {
             if buffers.len() <= segment_index {
@@ -538,7 +553,18 @@ impl Burst {
             }
 
             let segment = &mut segment[..max_segment_size];
-            let buffer_size = segment.len().min(self.path.mtu() as _);
+            let buffer_size = match datagram_capacity(
+                segment.len(),
+                self.path.mtu() as _,
+                reversed_size,
+                remaining_credit,
+            ) {
+                Ok(capacity) => capacity,
+                Err(error) if segment_lengths.is_empty() => {
+                    return Err(BurstError::Signals(error));
+                }
+                Err(_) => break,
+            };
             let buffer = &mut segment[..buffer_size][reversed_size..];
             let load_result = self
                 .load_spaces(data_sources, buffer)
@@ -581,18 +607,17 @@ impl Burst {
                     reversed_size + packet_size
                 });
 
-            match load_result {
+            let segment_length = match load_result {
                 Err(error) if segment_lengths.is_empty() => return Err(error),
                 Err(_) => break,
-                Ok(segment_length)
-                    if segment_length < segment_lengths.last().copied().unwrap_or_default() =>
-                {
-                    segment_lengths.push(segment_length);
-                    break;
-                }
-                Ok(segment_length) => {
-                    segment_lengths.push(segment_length);
-                }
+                Ok(segment_length) => segment_length,
+            };
+            remaining_credit = remaining_credit.saturating_sub(segment_length);
+            let final_segment =
+                segment_length < segment_lengths.last().copied().unwrap_or_default();
+            segment_lengths.push(segment_length);
+            if final_segment {
+                break;
             }
         }
 
@@ -601,5 +626,36 @@ impl Burst {
             .zip(buffers)
             .map(|(&len, buffer)| io::IoSlice::new(&buffer[..len]))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn amplification_credit_is_shared_by_all_segments() {
+        let mut remaining_credit = 3_600;
+        let mut total = 0;
+
+        for _ in 0..64 {
+            let Ok(capacity) = datagram_capacity(1_500, 1_200, 0, remaining_credit) else {
+                break;
+            };
+            remaining_credit -= capacity;
+            total += capacity;
+        }
+
+        assert_eq!(total, 3_600);
+        assert_eq!(remaining_credit, 0);
+    }
+
+    #[test]
+    fn forwarding_header_is_part_of_the_datagram_credit() {
+        assert_eq!(datagram_capacity(1_500, 1_200, 50, 1_200), Ok(1_200));
+        assert_eq!(
+            datagram_capacity(1_500, 1_200, 50, 50),
+            Err(Signals::CREDIT)
+        );
     }
 }

--- a/qinterface/src/component/route/queue.rs
+++ b/qinterface/src/component/route/queue.rs
@@ -59,28 +59,99 @@ impl RcvdPacketQueue {
         self.one_rtt.close();
     }
 
+    /// A per-connection queue must never backpressure the shared UDP receive loop.
     pub async fn deliver(&self, packet: Packet, way: Way) {
         match packet {
             Packet::Data(packet) => match packet.header {
                 DataHeader::Long(long::DataHeader::Initial(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.initial.send((packet, way)).await;
+                    _ = self.initial.try_send((packet, way));
                 }
                 DataHeader::Long(long::DataHeader::Handshake(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.handshake.send((packet, way)).await;
+                    _ = self.handshake.try_send((packet, way));
                 }
                 DataHeader::Long(long::DataHeader::ZeroRtt(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.zero_rtt.send((packet, way)).await;
+                    _ = self.zero_rtt.try_send((packet, way));
                 }
                 DataHeader::Short(header) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.one_rtt.send((packet, way)).await;
+                    _ = self.one_rtt.try_send((packet, way));
                 }
             },
             Packet::VN(_vn) => {}
             Packet::Retry(_retry) => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, time::Duration};
+
+    use bytes::BytesMut;
+    use qbase::{
+        cid::ConnectionId,
+        net::route::{Link, Pathway},
+        packet::{DataPacket, LongHeaderBuilder},
+    };
+
+    use super::*;
+    use crate::bind_uri::BindUri;
+
+    fn initial_packet() -> Packet {
+        let header = LongHeaderBuilder::with_cid(
+            ConnectionId::from_slice(b"destination"),
+            ConnectionId::from_slice(b"source"),
+        )
+        .initial(Vec::new());
+        Packet::Data(DataPacket {
+            header: DataHeader::Long(long::DataHeader::Initial(header)),
+            bytes: BytesMut::new(),
+            offset: 0,
+        })
+    }
+
+    fn way() -> Way {
+        let local = SocketAddr::from(([127, 0, 0, 1], 4433));
+        let remote = SocketAddr::from(([192, 0, 2, 1], 50000));
+        let link = Link::new(local, remote);
+        (BindUri::from(local), Pathway::from(link), link)
+    }
+
+    #[tokio::test]
+    async fn deliver_enqueues_when_capacity_is_available() {
+        let queue = RcvdPacketQueue::new();
+
+        queue.deliver(initial_packet(), way()).await;
+
+        assert!(queue.initial().recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn deliver_does_not_wait_for_a_full_connection_queue() {
+        let queue = RcvdPacketQueue::new();
+        loop {
+            let Packet::Data(packet) = initial_packet() else {
+                unreachable!()
+            };
+            let DataHeader::Long(long::DataHeader::Initial(header)) = packet.header else {
+                unreachable!()
+            };
+            let packet = CipherPacket::new(header, packet.bytes, packet.offset);
+            match queue.initial.try_send((packet, way())) {
+                Ok(()) => {}
+                Err(error) if error.is_full() => break,
+                Err(error) => panic!("queue closed while filling it: {error}"),
+            }
+        }
+
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            queue.deliver(initial_packet(), way()),
+        )
+        .await
+        .expect("routing must not wait for one connection's full queue");
     }
 }

--- a/qtraversal/src/nat/client.rs
+++ b/qtraversal/src/nat/client.rs
@@ -3,17 +3,16 @@ use std::{
     fmt,
     io::{self},
     net::SocketAddr,
-    ops::{ControlFlow, Deref},
-    pin::pin,
+    ops::Deref,
     sync::{
         Arc, Mutex, MutexGuard,
-        atomic::{AtomicBool, AtomicU8, Ordering::SeqCst},
+        atomic::{AtomicBool, Ordering::SeqCst},
     },
     task::{Context, Poll, ready},
     time::Duration,
 };
 
-use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
+use futures::{FutureExt, StreamExt};
 use qbase::net::{Family, addr::EndpointAddr};
 pub use qbase::net::{NatType, NetFeature};
 use qinterface::{
@@ -29,7 +28,7 @@ use qinterface::{
 };
 use qresolve::Resolve;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::{sync::Notify, task::JoinSet};
+use tokio::task::JoinSet;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Instrument;
 
@@ -44,6 +43,7 @@ use crate::{
 };
 
 const NAT_MAPPING_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+const MAX_STUN_AGENTS: usize = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NatDetectionStep {
@@ -166,79 +166,6 @@ impl From<DetectNatTypeError> for io::Error {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClientState {
-    Active = 0,
-    Inactive = 1,
-    Closing = 2,
-}
-
-#[derive(Debug, Clone)]
-struct ArcClientState {
-    state: Arc<AtomicU8>,
-    observers: [Arc<Notify>; 3],
-}
-
-impl ArcClientState {
-    pub fn new() -> Self {
-        Self {
-            state: Arc::new(AtomicU8::new(ClientState::Active as u8)),
-            observers: <[_; 3]>::default(),
-        }
-    }
-
-    pub fn try_update(&self, old_state: ClientState, new_state: ClientState) -> bool {
-        match self
-            .state
-            .compare_exchange(old_state as u8, new_state as u8, SeqCst, SeqCst)
-        {
-            Ok(_old) => {
-                self.observers[new_state as usize].notify_waiters();
-                true
-            }
-            Err(_current) => false,
-        }
-    }
-
-    pub fn get(&self) -> ClientState {
-        match self.state.load(SeqCst) {
-            0 => ClientState::Active,
-            1 => ClientState::Inactive,
-            2 => ClientState::Closing,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn set(&self, new_state: ClientState) -> ClientState {
-        let old_state = self.state.swap(new_state as u8, SeqCst);
-        if old_state != new_state as u8 {
-            self.observers[new_state as usize].notify_waiters();
-        }
-        match old_state {
-            0 => ClientState::Active,
-            1 => ClientState::Inactive,
-            2 => ClientState::Closing,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn wait(&self, expect: ClientState) -> impl futures::Future<Output = ()> + use<> {
-        let notify = self.observers[expect as usize].clone();
-        let state = self.state.clone();
-        async move {
-            let mut notified = pin!(notify.notified());
-            loop {
-                notified.as_mut().enable();
-                if state.load(SeqCst) == expect as u8 {
-                    return;
-                }
-                notified.as_mut().await;
-                notified.set(notify.notified());
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct StunClient<I: RefIO + 'static> {
     #[allow(clippy::type_complexity)]
@@ -250,7 +177,7 @@ pub struct StunClient<I: RefIO + 'static> {
     stun_agent: SocketAddr,
     endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
 
-    state: ArcClientState,
+    closing: Arc<AtomicBool>,
     tasks: Arc<Mutex<JoinSet<()>>>,
 }
 
@@ -277,7 +204,7 @@ impl<I: RefIO + 'static> StunClient<I> {
             ref_iface,
             stun_router,
             endpoint_publisher: Arc::new(Mutex::new(endpoint_publisher)),
-            state: ArcClientState::new(),
+            closing: Arc::new(AtomicBool::new(false)),
             tasks: Arc::new(Mutex::new(JoinSet::new())),
         };
         tracing::debug!(target: "stun", %stun_agent, "created new STUN client");
@@ -304,8 +231,6 @@ impl<I: RefIO + 'static> StunClient<I> {
         let bind_uri = ref_iface.iface().bind_uri();
 
         let endpoint_publisher = self.endpoint_publisher.clone();
-
-        let client_state = self.state.clone();
 
         let keep_alive_task = async move {
             let log_detect_result = |detect_result: &Result<SocketAddr, DetectOuterAddrError>| {
@@ -344,11 +269,6 @@ impl<I: RefIO + 'static> StunClient<I> {
                     Duration::from_millis(300),
                 )
                 .await;
-
-                match &detect_result {
-                    Ok(_) => client_state.try_update(ClientState::Inactive, ClientState::Active),
-                    Err(_) => client_state.try_update(ClientState::Active, ClientState::Inactive),
-                };
 
                 log_detect_result(&detect_result);
 
@@ -390,7 +310,7 @@ impl<I: RefIO + 'static> StunClient<I> {
         &self,
         cx: &mut Context,
     ) -> Poll<Result<SocketAddr, DetectOuterAddrError>> {
-        if self.state.get() == ClientState::Closing {
+        if self.closing.load(SeqCst) {
             return Poll::Ready(Err(DetectOuterAddrError::Rebinded {
                 bind_uri: self.ref_iface.iface().bind_uri(),
             }));
@@ -407,7 +327,7 @@ impl<I: RefIO + 'static> StunClient<I> {
     }
 
     pub fn get_outer_addr(&self) -> Option<Result<SocketAddr, DetectOuterAddrError>> {
-        if self.state.get() == ClientState::Closing {
+        if self.closing.load(SeqCst) {
             return Some(Err(DetectOuterAddrError::Rebinded {
                 bind_uri: self.ref_iface.iface().bind_uri(),
             }));
@@ -445,7 +365,7 @@ impl<I: RefIO + 'static> StunClient<I> {
     }
 
     pub fn poll_nat_type(&self, cx: &mut Context) -> Poll<Result<NatType, DetectNatTypeError>> {
-        if self.state.get() == ClientState::Closing {
+        if self.closing.load(SeqCst) {
             return Poll::Ready(Err(DetectNatTypeError::Rebinded {
                 bind_uri: self.ref_iface.iface().bind_uri(),
             }));
@@ -458,7 +378,7 @@ impl<I: RefIO + 'static> StunClient<I> {
     }
 
     pub fn get_nat_type(&self) -> Option<Result<NatType, DetectNatTypeError>> {
-        if self.state.get() == ClientState::Closing {
+        if self.closing.load(SeqCst) {
             return Some(Err(DetectNatTypeError::Rebinded {
                 bind_uri: self.ref_iface.iface().bind_uri(),
             }));
@@ -477,7 +397,7 @@ impl<I: RefIO + 'static> StunClient<I> {
     // }
 
     pub fn poll_close(&self, cx: &mut Context) -> Poll<()> {
-        if self.state.set(ClientState::Closing) == ClientState::Closing {
+        if self.closing.swap(true, SeqCst) {
             return Poll::Ready(());
         }
         self.lock_tasks().abort_all();
@@ -554,6 +474,35 @@ impl Component for StunClientComponent {
 
 type StunClientsMap<I> = HashMap<SocketAddr, StunClient<I>>;
 
+async fn resolve_stun_agents(
+    resolver: &(dyn Resolve + Send + Sync),
+    server: &str,
+    family: Family,
+) -> Vec<SocketAddr> {
+    let Ok(mut records) = resolver.lookup(server).await else {
+        return Vec::new();
+    };
+    let mut agents = Vec::with_capacity(MAX_STUN_AGENTS);
+
+    while let Some((_, endpoint)) = records.next().await {
+        let EndpointAddr::Direct { addr } = endpoint else {
+            continue;
+        };
+        let matches_family = match family {
+            Family::V4 => addr.is_ipv4(),
+            Family::V6 => addr.is_ipv6(),
+        };
+        if matches_family && !agents.contains(&addr) {
+            agents.push(addr);
+            if agents.len() == MAX_STUN_AGENTS {
+                break;
+            }
+        }
+    }
+
+    agents
+}
+
 #[derive(Debug)]
 struct StunClientsInner<I: RefIO + 'static> {
     ref_iface: I,
@@ -566,8 +515,6 @@ struct StunClientsInner<I: RefIO + 'static> {
 pub const DEFAULT_STUN_SERVER: &str = "nat.genmeta.net:20004";
 
 impl<I: RefIO + 'static> StunClientsInner<I> {
-    pub const MIN_AGENTS: usize = 3;
-
     pub fn new(
         ref_iface: I,
         router: StunRouter,
@@ -606,61 +553,21 @@ impl<I: RefIO + 'static> StunClientsInner<I> {
             let clients = clients.clone();
             let resolver = resolver.clone();
             let server = server.clone();
-            let ref_iface = ref_iface.clone();
+            let family = ref_iface.iface().bind_uri().family();
             async move {
-                let lock_clients = || clients.lock().expect("StunClients mutex poisoned");
-
-                let should_lookup_agents = |clients: &StunClientsMap<I>| match clients
-                    .values()
-                    .try_fold((0, 0), |(active, inactive), client| {
-                        match client.state.get() {
-                            ClientState::Active => ControlFlow::Continue((active + 1, inactive)),
-                            ClientState::Inactive => ControlFlow::Continue((active, inactive + 1)),
-                            ClientState::Closing => ControlFlow::Break(()),
-                        }
-                    }) {
-                    ControlFlow::Continue((active, _inactive)) => active < Self::MIN_AGENTS,
-                    ControlFlow::Break(_) => false,
-                };
-
-                let wait_too_few_agents = |clients: &StunClientsMap<I>| {
-                    let clients_len = clients.len();
-                    debug_assert!(clients_len >= Self::MIN_AGENTS);
-                    let mut stream = clients
-                        .iter()
-                        .map(|(.., client)| client.state.wait(ClientState::Inactive))
-                        .collect::<FuturesUnordered<_>>()
-                        .skip(clients_len.saturating_sub(Self::MIN_AGENTS));
-                    async move { _ = stream.next().await }
-                };
-
-                loop {
-                    while !{ should_lookup_agents(&lock_clients()) } {
-                        { wait_too_few_agents(&lock_clients()) }.await;
+                for addr in resolve_stun_agents(resolver.as_ref(), server.as_ref(), family).await {
+                    let mut clients = clients.lock().expect("StunClients mutex poisoned");
+                    if clients.len() >= MAX_STUN_AGENTS {
+                        break;
                     }
-
-                    // 保证两次 lookup 至少间隔 10s，同时限时 10s 防止 resolver 卡住
-                    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-                    _ = tokio::time::timeout_at(deadline, async {
-                        let Ok(stream) = resolver.lookup(server.as_ref()).await else { return };
-                        let is_ipv4 = ref_iface.iface().bind_uri().family() == Family::V4;
-                        let mut stream = std::pin::pin!(stream);
-                        while let Some((_, addr)) = stream.next().await {
-                            let EndpointAddr::Direct { addr } = addr else { continue };
-                            if addr.is_ipv4() != is_ipv4 { continue }
-                            let done = {
-                                let mut clients = lock_clients();
-                                if clients.contains_key(&addr) { continue }
-                                if let Some(client) = new_stun_client(addr) {
-                                    tracing::debug!(target: "stun", %addr, "discovered new STUN agent");
-                                    clients.insert(addr, client);
-                                    !should_lookup_agents(&clients)
-                                } else { false }
-                            };
-                            if done { break }
-                        }
-                    }).await;
-                    tokio::time::sleep_until(deadline).await;
+                    if clients.contains_key(&addr) {
+                        continue;
+                    }
+                    let Some(client) = new_stun_client(addr) else {
+                        continue;
+                    };
+                    tracing::debug!(target: "stun", %addr, "discovered new STUN agent");
+                    clients.insert(addr, client);
                 }
             }
             .in_current_span()
@@ -767,7 +674,7 @@ impl Component for StunClientsComponent {
                 router,
                 clients.resolver.clone(),
                 clients.server.clone(),
-                clients.lock_clients().keys().copied(),
+                std::iter::empty(),
                 local_endpoints,
             );
             *clients = new_clinets;
@@ -1288,3 +1195,6 @@ async fn detect_nat_type<I: RefIO>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/qtraversal/src/nat/client/tests.rs
+++ b/qtraversal/src/nat/client/tests.rs
@@ -1,0 +1,107 @@
+use std::{
+    fmt,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use futures::{FutureExt, StreamExt, stream};
+use qresolve::{ResolveFuture, Source};
+
+use super::*;
+
+#[derive(Debug, Clone)]
+enum LookupResult {
+    Records(Vec<EndpointAddr>),
+    Error,
+}
+
+#[derive(Debug, Clone)]
+struct TestResolver {
+    lookups: Arc<AtomicUsize>,
+    result: LookupResult,
+}
+
+impl TestResolver {
+    fn new(result: LookupResult) -> Self {
+        Self {
+            lookups: Arc::new(AtomicUsize::new(0)),
+            result,
+        }
+    }
+
+    fn lookup_count(&self) -> usize {
+        self.lookups.load(Ordering::SeqCst)
+    }
+}
+
+impl fmt::Display for TestResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("test resolver")
+    }
+}
+
+impl Resolve for TestResolver {
+    fn lookup<'l>(&'l self, _name: &'l str) -> ResolveFuture<'l> {
+        self.lookups.fetch_add(1, Ordering::SeqCst);
+        let result = self.result.clone();
+        async move {
+            match result {
+                LookupResult::Records(endpoints) => Ok(stream::iter(
+                    endpoints
+                        .into_iter()
+                        .map(|endpoint| (Source::System, endpoint)),
+                )
+                .boxed()),
+                LookupResult::Error => Err(io::Error::other("lookup failed")),
+            }
+        }
+        .boxed()
+    }
+}
+
+fn direct(addr: &str) -> EndpointAddr {
+    EndpointAddr::direct(addr.parse().unwrap())
+}
+
+#[tokio::test]
+async fn single_dns_result_is_a_complete_snapshot() {
+    let resolver = TestResolver::new(LookupResult::Records(vec![direct("192.0.2.1:20004")]));
+
+    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+
+    assert_eq!(agents, vec!["192.0.2.1:20004".parse().unwrap()]);
+    assert_eq!(resolver.lookup_count(), 1);
+}
+
+#[tokio::test]
+async fn dns_snapshot_is_filtered_deduplicated_and_bounded() {
+    let resolver = TestResolver::new(LookupResult::Records(vec![
+        direct("192.0.2.1:20004"),
+        direct("192.0.2.1:20004"),
+        direct("[2001:db8::1]:20004"),
+        direct("192.0.2.2:20004"),
+        direct("192.0.2.3:20004"),
+        direct("192.0.2.4:20004"),
+    ]));
+
+    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+
+    assert_eq!(
+        agents,
+        vec![
+            "192.0.2.1:20004".parse().unwrap(),
+            "192.0.2.2:20004".parse().unwrap(),
+            "192.0.2.3:20004".parse().unwrap(),
+        ]
+    );
+    assert_eq!(resolver.lookup_count(), 1);
+}
+
+#[tokio::test]
+async fn dns_failure_is_not_retried() {
+    let resolver = TestResolver::new(LookupResult::Error);
+
+    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+
+    assert!(agents.is_empty());
+    assert_eq!(resolver.lookup_count(), 1);
+}

--- a/qtraversal/tests/reinit.rs
+++ b/qtraversal/tests/reinit.rs
@@ -1,7 +1,61 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    fmt, io,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
-use qinterface::{bind_uri::BindUri, io::handy::DEFAULT_IO_FACTORY, manager::InterfaceManager};
-use qtraversal::{nat::router::StunRouterComponent, route::ReceiveAndDeliverPacketComponent};
+use futures::{FutureExt, StreamExt, stream};
+use qbase::net::addr::EndpointAddr;
+use qinterface::{
+    bind_uri::BindUri, component::Component, io::handy::DEFAULT_IO_FACTORY,
+    manager::InterfaceManager,
+};
+use qresolve::{Resolve, ResolveFuture, Source};
+use qtraversal::{
+    nat::{client::StunClientsComponent, router::StunRouterComponent},
+    route::ReceiveAndDeliverPacketComponent,
+};
+
+#[derive(Debug, Clone, Default)]
+struct CountingResolver {
+    lookups: Arc<AtomicUsize>,
+}
+
+impl CountingResolver {
+    fn lookup_count(&self) -> usize {
+        self.lookups.load(Ordering::SeqCst)
+    }
+}
+
+impl fmt::Display for CountingResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("counting resolver")
+    }
+}
+
+impl Resolve for CountingResolver {
+    fn lookup<'l>(&'l self, _name: &'l str) -> ResolveFuture<'l> {
+        self.lookups.fetch_add(1, Ordering::SeqCst);
+        async move {
+            let records = stream::empty::<(Source, EndpointAddr)>().boxed();
+            Ok(records)
+        }
+        .boxed()
+    }
+}
+
+async fn wait_for_lookup_count(resolver: &CountingResolver, expected: usize) -> io::Result<()> {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while resolver.lookup_count() < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(io::Error::other)
+}
 
 fn test_bind_uri() -> BindUri {
     let base: BindUri = "inet://127.0.0.1:0".into();
@@ -45,4 +99,39 @@ async fn receive_reinit_refreshes_stun_router_dependency() {
         .expect("stale stun router did not close")
         .expect("stale receive task panicked");
     assert!(received.is_none());
+}
+
+#[tokio::test]
+async fn stun_clients_lookup_once_for_each_interface_generation() {
+    let manager = InterfaceManager::global().clone();
+    let old_bind = manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    let old_iface = old_bind.borrow();
+    let stun = StunRouterComponent::new(old_iface.downgrade());
+    let resolver = CountingResolver::default();
+    let clients = StunClientsComponent::new(
+        old_iface.downgrade(),
+        stun.router(),
+        Arc::new(resolver.clone()),
+        "stun.example:20004",
+        std::iter::empty(),
+        None,
+    );
+    wait_for_lookup_count(&resolver, 1).await.unwrap();
+
+    let new_bind = manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    new_bind.insert_component_with(|_| stun);
+    new_bind.insert_component_with(|_| clients.clone());
+
+    let reinit_called = new_bind.with_components(|components, iface| {
+        components.with(|clients: &StunClientsComponent| clients.reinit(iface))
+    });
+    assert!(reinit_called.is_some());
+    wait_for_lookup_count(&resolver, 2).await.unwrap();
+    tokio::task::yield_now().await;
+
+    assert_eq!(resolver.lookup_count(), 2);
 }


### PR DESCRIPTION
- 修复单次 burst 包含多个数据段时可能突破 QUIC 放大限制的问题。
- 使用饱和运算，避免放大额度溢出或下溢。
- 避免单个连接的接收队列满载时阻塞公共 UDP 接收流程。
- STUN 地址改为每代接口只解析一次，DNS 返回 1 个地址也视为完整结果。
