### PR TITLE
chore: prepare dquic v0.7.0-beta.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,17 +97,17 @@ tracing-appender = "0.2"
 
 # members
 qmacro = { path = "./qmacro", version = "0.5.1" }
-qbase = { path = "./qbase", version = "0.6.0" }
+qbase = { path = "./qbase", version = "0.6.1" }
 qevent = { path = "./qevent", version = "0.6.0" }
 qudp = { path = "./qudp", version = "0.7.0-beta.1" }
-qinterface = { path = "./qinterface", version = "0.7.0-beta.2" }
+qinterface = { path = "./qinterface", version = "0.7.0-beta.3" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.4" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.5" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.8.0-beta.1" }
-dquic = { path = "./dquic", version = "0.7.0-beta.4" }
+qconnection = { path = "./qconnection", version = "0.8.0-beta.2" }
+dquic = { path = "./dquic", version = "0.7.0-beta.5" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.4"
+version = "0.7.0-beta.5"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbase"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 description = "Core structure of the QUIC protocol, a part of dquic"
 readme.workspace = true

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.8.0-beta.1"
+version = "0.8.0-beta.2"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.4"
+version = "0.7.0-beta.5"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"


### PR DESCRIPTION
## Release prep

Prepare the dquic transport release for tag `v0.7.0-beta.5`. The reliability fixes were merged into `main` by #733; this PR contains only the release-version alignment.

## Published crates

- `qbase` `0.6.1`
- `qinterface` `0.7.0-beta.3`
- `qtraversal` `0.7.0-beta.5`
- `qconnection` `0.8.0-beta.2`
- `dquic` `0.7.0-beta.5`

Unchanged workspace crates keep their existing published versions. `h3-shim` remains outside this release surface.

## Changes

The release carries the already-merged reliability work from #733:

- Isolate a full per-connection receive queue so it cannot block the shared UDP receive path.
- Enforce QUIC anti-amplification credit for every packet in a burst, using saturating arithmetic for credit accounting.
- Resolve STUN endpoints once per interface generation and accept a single DNS result as complete.

## Version rationale

The changed transport members move together so the published dependency graph resolves one compatible release line. `qbase` receives its patch release alongside the beta members; the remaining workspace crates are unchanged and are not republished.

## Verification

- `git diff --check origin/main...HEAD`
- Focused `cargo check` completed before the release-branch rebase.
- The wider integration suite was already run in the dedicated integration task and is intentionally not repeated here.

## Release gates

- Target branch: `main`
- Planned tag: `v0.7.0-beta.5`
- Release surface: crates.io plus tag-triggered GitHub Release
- Downstream waits: h3x, dyns, dhttp, pishoo, and gmutils must wait until these crate versions are published and visible on crates.io.

## Proposed annotated tag message

```markdown
# dquic v0.7.0-beta.5

## Changes

- Prevent one saturated connection queue from blocking shared UDP receive processing.
- Enforce anti-amplification credit across multi-packet bursts without accounting overflow or underflow.
- Make STUN endpoint resolution stable per interface generation.

## Published crates

- `qbase` v0.6.1
- `qinterface` v0.7.0-beta.3
- `qtraversal` v0.7.0-beta.5
- `qconnection` v0.8.0-beta.2
- `dquic` v0.7.0-beta.5
```