### PR TITLE
[WIP]fix(qconnection): correct amplification credit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,17 +97,17 @@ tracing-appender = "0.2"
 
 # members
 qmacro = { path = "./qmacro", version = "0.5.1" }
-qbase = { path = "./qbase", version = "0.6.1" }
+qbase = { path = "./qbase", version = "0.6.2" }
 qevent = { path = "./qevent", version = "0.6.0" }
 qudp = { path = "./qudp", version = "0.7.0-beta.1" }
-qinterface = { path = "./qinterface", version = "0.7.0-beta.3" }
+qinterface = { path = "./qinterface", version = "0.7.0-beta.4" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
 qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.5" }
+qtraversal = { path = "./qtraversal", version = "0.7.0-beta.6" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.8.0-beta.2" }
-dquic = { path = "./dquic", version = "0.7.0-beta.5" }
+qconnection = { path = "./qconnection", version = "0.8.0-beta.3" }
+dquic = { path = "./dquic", version = "0.7.0-beta.6" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.5"
+version = "0.7.0-beta.6"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/dquic/src/server.rs
+++ b/dquic/src/server.rs
@@ -30,7 +30,7 @@ use qconnection::{
 use qevent::telemetry::QLog;
 use qinterface::{
     BindInterface,
-    component::route::{QuicRouter, Way},
+    component::route::{QuicRouter, ReceivedPacket, Way},
     io::ProductIO,
     manager::InterfaceManager,
 };
@@ -434,7 +434,11 @@ impl QuicListeners {
         target = "dquic", level = "debug", skip_all,
         fields(%bind_uri, %pathway, %link, odcid=tracing::field::Empty, server_name=tracing::field::Empty)
     )]
-    pub(crate) fn try_accept_connection(&self, packet: Packet, (bind_uri, pathway, link): Way) {
+    pub(crate) fn try_accept_connection(
+        &self,
+        (packet, datagram_size): ReceivedPacket,
+        (bind_uri, pathway, link): Way,
+    ) {
         if let Err(error) =
             qinterface::component::route::validate_received_way(&(bind_uri.clone(), pathway, link))
         {
@@ -498,7 +502,9 @@ impl QuicListeners {
         let local_endpoints = self.network.local_endpoints.clone();
 
         let try_accept_connection = async move {
-            quic_router.deliver(packet, (bind_uri, pathway, link)).await;
+            quic_router
+                .deliver((packet, datagram_size), (bind_uri, pathway, link))
+                .await;
 
             match connection.server_name().await {
                 Ok(server_name) => {
@@ -981,10 +987,15 @@ mod path_admissibility_tests {
             link,
         );
 
-        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+        listeners.try_accept_connection((initial_packet(dcid), 1200), way.clone());
 
         assert_eq!(listeners.backlog.available_permits(), 1);
-        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
+        assert!(
+            router
+                .try_deliver((initial_packet(dcid), 0), way)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1002,9 +1013,14 @@ mod path_admissibility_tests {
         let link = Link::new(local, remote);
         let way = (BindUri::from(local), Pathway::from(link), link);
 
-        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+        listeners.try_accept_connection((initial_packet(dcid), 1200), way.clone());
 
         assert_eq!(listeners.backlog.available_permits(), 1);
-        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
+        assert!(
+            router
+                .try_deliver((initial_packet(dcid), 0), way)
+                .await
+                .is_err()
+        );
     }
 }

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbase"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 description = "Core structure of the QUIC protocol, a part of dquic"
 readme.workspace = true

--- a/qbase/src/packet.rs
+++ b/qbase/src/packet.rs
@@ -161,24 +161,34 @@ pub enum Packet {
 ///
 /// The received packet is a BytesMut, in order to be decrypted in future, and make as few
 /// copies cheaply until it is read by the application layer.
+///
+/// Each item also carries the size of its containing UDP datagram. For a coalesced datagram,
+/// only the first item carries the size; later items carry zero so receive accounting happens once.
 #[derive(Debug)]
 pub struct PacketReader {
     raw_bytes: BytesMut,
     dcid_len: usize,
+    datagram_size: usize,
     // TODO: 添加level，各种包类型顺序不能错乱，否则失败
 }
 
 impl PacketReader {
     pub fn new(raw_bytes: BytesMut, dcid_len: usize) -> Self {
+        let datagram_size = raw_bytes.len();
+        Self::with_datagram_size(raw_bytes, dcid_len, datagram_size)
+    }
+
+    pub fn with_datagram_size(raw_bytes: BytesMut, dcid_len: usize, datagram_size: usize) -> Self {
         Self {
             raw_bytes,
             dcid_len,
+            datagram_size,
         }
     }
 }
 
 impl Iterator for PacketReader {
-    type Item = Result<Packet, error::Error>;
+    type Item = Result<(Packet, usize), error::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.raw_bytes.is_empty() {
@@ -186,7 +196,7 @@ impl Iterator for PacketReader {
         }
 
         match io::be_packet(&mut self.raw_bytes, self.dcid_len) {
-            Ok(packet) => Some(Ok(packet)),
+            Ok(packet) => Some(Ok((packet, std::mem::take(&mut self.datagram_size)))),
             Err(error) => {
                 tracing::debug!(target: "dquic", ?error, "dropped unparsed packet");
                 self.raw_bytes.clear(); // no longer parsing

--- a/qbase/src/packet/io.rs
+++ b/qbase/src/packet/io.rs
@@ -903,5 +903,27 @@ mod tests {
             ]
             .as_slice()
         );
+
+        let mut padded = BytesMut::from(&buffer[..sent_bytes]);
+        padded.resize(1200, 0);
+        let (Packet::Data(packet), datagram_size) =
+            PacketReader::new(padded, 8).next().unwrap().unwrap()
+        else {
+            panic!("expected Initial packet");
+        };
+        assert_eq!(packet.bytes.len(), sent_bytes);
+        assert_eq!(datagram_size, 1200);
+
+        let mut coalesced = BytesMut::from(&buffer[..sent_bytes]);
+        coalesced.extend_from_slice(&buffer[..sent_bytes]);
+        let mut packets = PacketReader::new(coalesced, 8);
+        let (Packet::Data(_first), first_datagram_size) = packets.next().unwrap().unwrap() else {
+            panic!("expected first Initial packet");
+        };
+        let (Packet::Data(_second), second_datagram_size) = packets.next().unwrap().unwrap() else {
+            panic!("expected second Initial packet");
+        };
+        assert_eq!(first_datagram_size, sent_bytes * 2);
+        assert_eq!(second_datagram_size, 0);
     }
 }

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -245,11 +245,11 @@ impl Path {
         &self,
         epoch: Epoch,
         pn: u64,
-        size: usize,
+        datagram_size: usize,
         packet_content: PacketContent,
     ) {
-        self.anti_amplifier.on_rcvd(size);
-        if size > 0 {
+        if datagram_size > 0 {
+            self.anti_amplifier.on_rcvd(datagram_size);
             self.status.release_anti_amplification_limit();
         }
         self.idle_timer.on_rcvd(packet_content);

--- a/qconnection/src/path/aa.rs
+++ b/qconnection/src/path/aa.rs
@@ -117,7 +117,55 @@ impl<const N: usize> AntiAmplifier<N> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
+    use qbase::packet::{Packet, PacketReader};
+
     use super::*;
+
+    #[test]
+    fn udp_bytes_after_initial_length_count_toward_amplification_credit() {
+        const INITIAL_PACKET_SIZE: usize = 290;
+        const DATAGRAM_SIZE: usize = 1200;
+
+        // The two-byte Length field is 272 (0x110 with the 01 varint prefix).
+        // With the 18-byte long header, only the first 290 bytes belong to the
+        // Initial packet. The remaining UDP payload is deliberately outside it.
+        let mut datagram = BytesMut::from(
+            &[
+                0xc0, // Initial, packet number length 1
+                0x00, 0x00, 0x00, 0x01, // QUIC v1
+                8,    // DCID length
+                0, 1, 2, 3, 4, 5, 6, 7, // DCID
+                0, // SCID length
+                0, // token length
+                0x41, 0x10, // Length = 272
+            ][..],
+        );
+        datagram.resize(INITIAL_PACKET_SIZE, 0);
+        datagram.resize(DATAGRAM_SIZE, 0);
+
+        let (Packet::Data(initial), datagram_size) = PacketReader::new(datagram, 8)
+            .next()
+            .expect("datagram contains an Initial packet")
+            .expect("Initial packet is parseable")
+        else {
+            panic!("expected an Initial packet");
+        };
+
+        assert_eq!(initial.bytes.len(), INITIAL_PACKET_SIZE);
+        assert_eq!(datagram_size, DATAGRAM_SIZE);
+
+        let anti_amplifier = AntiAmplifier::<3>::new(ArcSendWaker::new());
+        anti_amplifier.on_rcvd(datagram_size);
+
+        assert_eq!(anti_amplifier.balance(), Ok(Some(DATAGRAM_SIZE * 3)));
+        assert_ne!(
+            anti_amplifier.balance(),
+            Ok(Some(INITIAL_PACKET_SIZE * 3)),
+            "credit must not be derived from the Initial packet Length field"
+        );
+    }
+
     #[test]
     fn test_deposit_and_poll_apply() {
         let waker = ArcSendWaker::new();

--- a/qconnection/src/space/data.rs
+++ b/qconnection/src/space/data.rs
@@ -50,11 +50,11 @@ use crate::{
 
 pub type CipherZeroRttPacket = CipherPacket<ZeroRttHeader>;
 pub type PlainZeroRttPacket = PlainPacket<ZeroRttHeader>;
-pub type ReceivedZeroRttFrom = (CipherZeroRttPacket, (BindUri, Pathway, Link));
+pub type ReceivedZeroRttFrom = ((CipherZeroRttPacket, usize), (BindUri, Pathway, Link));
 
 pub type CipherOneRttPacket = CipherPacket<OneRttHeader>;
 pub type PlainOneRttPacket = PlainPacket<OneRttHeader>;
-pub type ReceivedOneRttFrom = (CipherOneRttPacket, (BindUri, Pathway, Link));
+pub type ReceivedOneRttFrom = ((CipherOneRttPacket, usize), (BindUri, Pathway, Link));
 
 pub struct DataSpace {
     zero_rtt_keys: ArcZeroRttKeys,
@@ -418,7 +418,7 @@ fn frame_dispathcer(
 }
 
 async fn parse_normal_zero_rtt_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedZeroRttFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedZeroRttFrom,
     space: &DataSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, Type, &Path),
@@ -456,13 +456,13 @@ async fn parse_normal_zero_rtt_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Data),
     );
-    path.on_packet_rcvd(Epoch::Data, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Data, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
 
 async fn parse_normal_one_rtt_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedOneRttFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedOneRttFrom,
     space: &DataSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, Type, &Path),
@@ -503,7 +503,7 @@ async fn parse_normal_one_rtt_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Data),
     );
-    path.on_packet_rcvd(Epoch::Data, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Data, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
@@ -605,7 +605,7 @@ pub async fn deliver_and_parse_packets(
     drop(components);
     zeor_rtt_packets.close();
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = one_rtt_packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = one_rtt_packets.recv().await {
         if let Some(ccf) = parse_closing_one_rtt_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/space/handshake.rs
+++ b/qconnection/src/space/handshake.rs
@@ -34,7 +34,7 @@ use crate::{
 
 pub type CipherHanshakePacket = CipherPacket<HandshakeHeader>;
 pub type PlainHandshakePacket = PlainPacket<HandshakeHeader>;
-pub type ReceivedFrom = (CipherHanshakePacket, Way);
+pub type ReceivedFrom = ((CipherHanshakePacket, usize), Way);
 
 pub struct HandshakeSpace {
     keys: ArcKeys,
@@ -182,7 +182,7 @@ fn frame_dispathcer<'a>(
 }
 
 async fn parse_normal_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedFrom,
     space: &HandshakeSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, &Path),
@@ -224,7 +224,7 @@ async fn parse_normal_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Handshake),
     );
-    path.on_packet_rcvd(Epoch::Handshake, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Handshake, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
@@ -290,7 +290,7 @@ pub async fn deliver_and_parse_packets(
     // Release the primary connection state
     drop(components);
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = packets.recv().await {
         if let Some(ccf) = parse_closing_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/space/initial.rs
+++ b/qconnection/src/space/initial.rs
@@ -42,7 +42,7 @@ use crate::{
 
 pub type CipherInitialPacket = CipherPacket<InitialHeader>;
 pub type PlainInitialPacket = PlainPacket<InitialHeader>;
-pub type ReceivedFrom = (CipherInitialPacket, Way);
+pub type ReceivedFrom = ((CipherInitialPacket, usize), Way);
 
 pub struct InitialSpace {
     keys: ArcKeys,
@@ -184,7 +184,7 @@ fn frame_dispathcer<'a>(
 }
 
 async fn parse_normal_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedFrom,
     space: &InitialSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, &Path),
@@ -255,7 +255,7 @@ async fn parse_normal_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Initial),
     );
-    path.on_packet_rcvd(Epoch::Initial, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Initial, packet.pn(), datagram_size, packet_content);
 
     // Negotiate handshake path
     if paths.assign_handshake_path(&path, remote_cids, *packet.scid()) {
@@ -336,7 +336,7 @@ pub async fn deliver_and_parse_packets(
     // Release the primary connection state
     drop(components);
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = packets.recv().await {
         if let Some(ccf) = parse_closing_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/termination.rs
+++ b/qconnection/src/termination.rs
@@ -233,7 +233,7 @@ mod tests {
 
     async fn route_exists(router: &Arc<QuicRouter>, dcid: ConnectionId) -> bool {
         router
-            .try_deliver(test_routed_packet(dcid), test_way())
+            .try_deliver((test_routed_packet(dcid), 0), test_way())
             .await
             .is_ok()
     }

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.0-beta.3"
+version = "0.7.0-beta.4"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -30,11 +30,13 @@ pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;
 pub use queue::RcvdPacketQueue;
+/// A parsed QUIC packet paired with the size of its containing UDP datagram.
+pub type ReceivedPacket<P = Packet> = (P, usize);
 
 #[derive(Debug)]
 pub struct QuicRouter {
     table: DashMap<Signpost, Arc<RcvdPacketQueue>>,
-    on_unrouted: handler::PacketHandler<Packet>,
+    on_unrouted: handler::PacketHandler<ReceivedPacket>,
 }
 
 impl QuicRouter {
@@ -90,18 +92,22 @@ impl QuicRouter {
     }
 
     #[allow(clippy::result_large_err)]
-    pub async fn try_deliver(&self, packet: Packet, way: Way) -> Result<(), (Packet, Way)> {
-        match self.find_entry(&packet, &way.2) {
+    pub async fn try_deliver(
+        &self,
+        received: ReceivedPacket,
+        way: Way,
+    ) -> Result<(), (ReceivedPacket, Way)> {
+        match self.find_entry(&received.0, &way.2) {
             Some(rcvd_pkt_q) => {
-                rcvd_pkt_q.deliver(packet, way).await;
+                rcvd_pkt_q.deliver(received, way).await;
                 Ok(())
             }
-            None => Err((packet, way)),
+            None => Err((received, way)),
         }
     }
 
-    pub async fn deliver(&self, packet: Packet, way: Way) {
-        let rcvd_pkt_q = match self.find_entry(&packet, &way.2) {
+    pub async fn deliver(&self, received: ReceivedPacket, way: Way) {
+        let rcvd_pkt_q = match self.find_entry(&received.0, &way.2) {
             Some(rcvd_pkt_q) => rcvd_pkt_q,
             None => {
                 // For packets that cannot be routed, this likely indicates a new connection.
@@ -114,21 +120,21 @@ impl QuicRouter {
                 };
                 // Therefore, we retry routing here to allow thread B to route its packet
                 // to the connection created by thread A, instead of creating another new connection.
-                match self.find_entry(&packet, &way.2) {
+                match self.find_entry(&received.0, &way.2) {
                     Some(rcvd_pkt_q) => rcvd_pkt_q,
                     None => {
-                        (on_unrouted)(packet, way);
+                        (on_unrouted)(received, way);
                         return;
                     }
                 }
             }
         };
-        rcvd_pkt_q.deliver(packet, way).await;
+        rcvd_pkt_q.deliver(received, way).await;
     }
 
     pub fn on_connectless_packets<S>(&self, sink: S) -> bool
     where
-        S: Fn(Packet, Way) + Send + 'static,
+        S: Fn(ReceivedPacket, Way) + Send + 'static,
     {
         let mut on_unrouted = self.on_unrouted.lock();
         if on_unrouted.is_some() {

--- a/qinterface/src/component/route/queue.rs
+++ b/qinterface/src/component/route/queue.rs
@@ -6,9 +6,9 @@ use qbase::{
     util::BoundQueue,
 };
 
-use crate::component::route::{CipherPacket, Way};
+use crate::component::route::{CipherPacket, ReceivedPacket, Way};
 
-type PacketQueue<P> = BoundQueue<(CipherPacket<P>, Way)>;
+type PacketQueue<P> = BoundQueue<(ReceivedPacket<CipherPacket<P>>, Way)>;
 
 // 需要一个四元组，pathway + src + dst
 #[derive(Debug)]
@@ -60,24 +60,24 @@ impl RcvdPacketQueue {
     }
 
     /// A per-connection queue must never backpressure the shared UDP receive loop.
-    pub async fn deliver(&self, packet: Packet, way: Way) {
+    pub async fn deliver(&self, (packet, datagram_size): ReceivedPacket, way: Way) {
         match packet {
             Packet::Data(packet) => match packet.header {
                 DataHeader::Long(long::DataHeader::Initial(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.initial.try_send((packet, way));
+                    _ = self.initial.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Long(long::DataHeader::Handshake(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.handshake.try_send((packet, way));
+                    _ = self.handshake.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Long(long::DataHeader::ZeroRtt(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.zero_rtt.try_send((packet, way));
+                    _ = self.zero_rtt.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Short(header) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.one_rtt.try_send((packet, way));
+                    _ = self.one_rtt.try_send(((packet, datagram_size), way));
                 }
             },
             Packet::VN(_vn) => {}
@@ -124,9 +124,10 @@ mod tests {
     async fn deliver_enqueues_when_capacity_is_available() {
         let queue = RcvdPacketQueue::new();
 
-        queue.deliver(initial_packet(), way()).await;
+        queue.deliver((initial_packet(), 1200), way()).await;
 
-        assert!(queue.initial().recv().await.is_some());
+        let ((_packet, datagram_size), _) = queue.initial().recv().await.unwrap();
+        assert_eq!(datagram_size, 1200);
     }
 
     #[tokio::test]
@@ -140,7 +141,7 @@ mod tests {
                 unreachable!()
             };
             let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-            match queue.initial.try_send((packet, way())) {
+            match queue.initial.try_send(((packet, 1200), way())) {
                 Ok(()) => {}
                 Err(error) if error.is_full() => break,
                 Err(error) => panic!("queue closed while filling it: {error}"),
@@ -149,7 +150,7 @@ mod tests {
 
         tokio::time::timeout(
             Duration::from_millis(25),
-            queue.deliver(initial_packet(), way()),
+            queue.deliver((initial_packet(), 1200), way()),
         )
         .await
         .expect("routing must not wait for one connection's full queue");

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }
+rustls = { workspace = true }
 tokio = { features = ["fs", "rt-multi-thread"], workspace = true }
 
 [dev-dependencies.tracing-subscriber]

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.5"
+version = "0.7.0-beta.6"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -24,7 +24,7 @@ use qbase::{
     packet::{
         Package, PacketSpace, ProductHeader,
         header::short::OneRttHeader,
-        io::{AssemblePacket, Packages, PadTo20},
+        io::{AssemblePacket, Packages, PadToFull},
     },
 };
 use qevent::telemetry::Instrument;
@@ -198,6 +198,27 @@ const BIRTHDAY_TIMEOUT: Duration = Duration::from_secs(8);
 const MAX_RETRIES: usize = 5;
 const COLLISION_PORTS: u32 = 800;
 const PUNCHER_LOCAL_SHARDS: usize = 2;
+// A received punch must fund at least one full-size PATH_CHALLENGE and PATH_RESPONSE
+// exchange under QUIC's three-times anti-amplification limit.
+const PUNCH_DATAGRAM_SIZE: usize = 1_200;
+
+fn assemble_punch_packet<PH, S, P>(
+    product_header: &PH,
+    packet_space: &S,
+    buffer: &mut [u8],
+    packages: P,
+) -> Result<usize, Signals>
+where
+    PH: ProductHeader<OneRttHeader>,
+    S: PacketSpace<OneRttHeader>,
+    P: for<'b> Package<S::PacketAssembler<'b>>,
+    PadToFull: for<'b> Package<S::PacketAssembler<'b>>,
+{
+    let mut packet = packet_space.new_packet(product_header.new_header()?, buffer)?;
+    packet.assemble_packet(&mut Packages((packages, PadToFull)))?;
+    let (sent_bytes, _props) = packet.encrypt_and_protect_packet();
+    Ok(sent_bytes)
+}
 
 pub struct ArcPuncher<TX, PH, S>(Arc<Puncher<TX, PH, S>>);
 
@@ -316,17 +337,15 @@ where
     ) -> io::Result<()>
     where
         P: for<'b> Package<S::PacketAssembler<'b>>,
-        PadTo20: for<'b> Package<S::PacketAssembler<'b>>,
+        PadToFull: for<'b> Package<S::PacketAssembler<'b>>,
     {
-        let mut buffer = [0; 128];
-        let sent_bytes = (|| {
-            let mut packet = self
-                .packet_space
-                .new_packet(self.product_header.new_header()?, &mut buffer)?;
-            packet.assemble_packet(&mut Packages((packages, PadTo20)))?;
-            let (sent_bytes, _props) = packet.encrypt_and_protect_packet();
-            Result::<_, Signals>::Ok(sent_bytes)
-        })()
+        let mut buffer = [0; PUNCH_DATAGRAM_SIZE];
+        let sent_bytes = assemble_punch_packet(
+            &self.product_header,
+            self.packet_space.as_ref(),
+            &mut buffer,
+            packages,
+        )
         .map_err(|s| io::Error::other(format!("Failed to assemble packet: {s:?}")))?;
 
         let line = Line::new(link, ttl, None, sent_bytes as u16);
@@ -344,7 +363,7 @@ where
         ttl: u8,
     ) -> io::Result<()>
     where
-        PadTo20: for<'b> Package<S::PacketAssembler<'b>>,
+        PadToFull: for<'b> Package<S::PacketAssembler<'b>>,
         PunchHelloFrame: for<'b> Package<S::PacketAssembler<'b>>,
     {
         tracing::debug!(target: "punch", %punch_id, %link, ttl, "starting collision attack");
@@ -458,7 +477,7 @@ where
     S: PacketSpace<OneRttHeader> + Send + Sync + 'static,
     for<'b> PunchDoneFrame: Package<S::PacketAssembler<'b>>,
     for<'b> PunchHelloFrame: Package<S::PacketAssembler<'b>>,
-    for<'b> PadTo20: Package<S::PacketAssembler<'b>>,
+    for<'b> PadToFull: Package<S::PacketAssembler<'b>>,
 {
     pub fn add_local_address(
         &self,
@@ -1707,7 +1726,7 @@ where
     S: PacketSpace<OneRttHeader> + Send + Sync + 'static,
     for<'b> PunchDoneFrame: Package<S::PacketAssembler<'b>>,
     for<'b> PunchHelloFrame: Package<S::PacketAssembler<'b>>,
-    for<'b> PadTo20: Package<S::PacketAssembler<'b>>,
+    for<'b> PadToFull: Package<S::PacketAssembler<'b>>,
 {
     type Output = ();
 
@@ -1754,7 +1773,7 @@ where
     S: PacketSpace<OneRttHeader> + Send + Sync + 'static,
     for<'b> PunchDoneFrame: Package<S::PacketAssembler<'b>>,
     for<'b> PunchHelloFrame: Package<S::PacketAssembler<'b>>,
-    for<'b> PadTo20: Package<S::PacketAssembler<'b>>,
+    for<'b> PadToFull: Package<S::PacketAssembler<'b>>,
 {
     type Output = ();
 
@@ -1841,7 +1860,170 @@ async fn dynamic_iface(
 
 #[cfg(test)]
 mod tests {
+    use bytes::{BufMut, buf::UninitSlice};
+    use qbase::{
+        cid::ConnectionId,
+        packet::{
+            KeyPhaseBit, PacketInfo, PacketNumber, PacketWriter, RecordFrame, keys::DirectionalKeys,
+        },
+        util::ContinuousData,
+    };
+
     use super::*;
+
+    struct TransparentKeys;
+
+    impl rustls::quic::PacketKey for TransparentKeys {
+        fn decrypt_in_place<'a>(
+            &self,
+            _packet_number: u64,
+            _header: &[u8],
+            payload: &'a mut [u8],
+        ) -> Result<&'a [u8], rustls::Error> {
+            Ok(&payload[..payload.len() - self.tag_len()])
+        }
+
+        fn encrypt_in_place(
+            &self,
+            _packet_number: u64,
+            _header: &[u8],
+            _payload: &mut [u8],
+        ) -> Result<rustls::quic::Tag, rustls::Error> {
+            Ok(rustls::quic::Tag::from([0; 16].as_slice()))
+        }
+
+        fn confidentiality_limit(&self) -> u64 {
+            0
+        }
+
+        fn integrity_limit(&self) -> u64 {
+            0
+        }
+
+        fn tag_len(&self) -> usize {
+            16
+        }
+    }
+
+    impl rustls::quic::HeaderProtectionKey for TransparentKeys {
+        fn decrypt_in_place(
+            &self,
+            _sample: &[u8],
+            _first_byte: &mut u8,
+            _payload: &mut [u8],
+        ) -> Result<(), rustls::Error> {
+            Ok(())
+        }
+
+        fn encrypt_in_place(
+            &self,
+            _sample: &[u8],
+            _first_byte: &mut u8,
+            _payload: &mut [u8],
+        ) -> Result<(), rustls::Error> {
+            Ok(())
+        }
+
+        fn sample_len(&self) -> usize {
+            20
+        }
+    }
+
+    struct TestHeader;
+
+    impl ProductHeader<OneRttHeader> for TestHeader {
+        fn new_header(&self) -> Result<OneRttHeader, Signals> {
+            Ok(OneRttHeader::new(false.into(), ConnectionId::default()))
+        }
+    }
+
+    struct TestPacketSpace {
+        keys: DirectionalKeys,
+    }
+
+    struct TestPacketWriter<'b>(PacketWriter<'b>);
+
+    impl<'b> AsRef<PacketWriter<'b>> for TestPacketWriter<'b> {
+        fn as_ref(&self) -> &PacketWriter<'b> {
+            &self.0
+        }
+    }
+
+    unsafe impl BufMut for TestPacketWriter<'_> {
+        fn remaining_mut(&self) -> usize {
+            self.0.remaining_mut()
+        }
+
+        unsafe fn advance_mut(&mut self, cnt: usize) {
+            unsafe { self.0.advance_mut(cnt) };
+        }
+
+        fn chunk_mut(&mut self) -> &mut UninitSlice {
+            self.0.chunk_mut()
+        }
+
+        fn put_bytes(&mut self, val: u8, cnt: usize) {
+            self.0.put_bytes(val, cnt);
+        }
+    }
+
+    impl AssemblePacket for TestPacketWriter<'_> {
+        fn encrypt_and_protect_packet(self) -> (usize, PacketInfo) {
+            self.0.encrypt_and_protect_packet()
+        }
+    }
+
+    impl<'b, F, D: ContinuousData> RecordFrame<F, D> for TestPacketWriter<'b>
+    where
+        PacketWriter<'b>: RecordFrame<F, D>,
+    {
+        fn record_frame(&mut self, frame: &F) {
+            self.0.record_frame(frame);
+        }
+    }
+
+    impl TestPacketSpace {
+        fn new() -> Self {
+            let keys = Arc::new(TransparentKeys);
+            Self {
+                keys: DirectionalKeys {
+                    header: keys.clone(),
+                    packet: keys,
+                },
+            }
+        }
+    }
+
+    impl PacketSpace<OneRttHeader> for TestPacketSpace {
+        type PacketAssembler<'b> = TestPacketWriter<'b>;
+
+        fn new_packet<'b>(
+            &'b self,
+            header: OneRttHeader,
+            buffer: &'b mut [u8],
+        ) -> Result<Self::PacketAssembler<'b>, Signals> {
+            PacketWriter::new_short(
+                &header,
+                buffer,
+                (0, PacketNumber::U16(0)),
+                self.keys.clone(),
+                KeyPhaseBit::Zero,
+            )
+            .map(TestPacketWriter)
+        }
+    }
+
+    #[test]
+    fn punch_hello_funds_full_size_path_validation() {
+        let mut buffer = [0; PUNCH_DATAGRAM_SIZE];
+        let frame = PunchHelloFrame::new(0, 0, DEFAULT_PROBE_ID);
+
+        let sent_bytes =
+            assemble_punch_packet(&TestHeader, &TestPacketSpace::new(), &mut buffer, frame)
+                .expect("PunchHello packet should assemble");
+
+        assert_eq!(sent_bytes, PUNCH_DATAGRAM_SIZE);
+    }
 
     #[test]
     fn direct_pairing_rejects_loopback_to_non_loopback() {

--- a/qtraversal/src/route.rs
+++ b/qtraversal/src/route.rs
@@ -40,6 +40,12 @@ use crate::{
     packet::{ForwardHeader, StunHeader},
 };
 
+const INITIAL_MINIMUM_DATAGRAM_SIZE: usize = 1_200;
+// The QUIC packet is measured after the forwarding header is removed. Keep a
+// 100-byte budget for that header so an Initial still represents a minimum-size
+// datagram on the wire.
+const INITIAL_MINIMUM_PACKET_SIZE: usize = INITIAL_MINIMUM_DATAGRAM_SIZE - 100;
+
 #[derive(Debug, Clone)]
 pub enum Forwarder<I: RefIO + 'static> {
     Clients { stun_clients: StunClients<I> },
@@ -186,7 +192,8 @@ impl ReceiveAndDeliverPacketComponent {
                 let iface = iface_ref.iface();
                 let bind_uri = iface.bind_uri();
 
-            let deliver_quic_packet = async |pkt: BytesMut, route: Route| {
+            let deliver_quic_packet =
+                async |pkt: BytesMut, route: Route, datagram_size: usize| {
                 let Some(quic_router) = quic_router.as_ref() else {
                     return;
                 };
@@ -196,14 +203,18 @@ impl ReceiveAndDeliverPacketComponent {
                     matches!(pkt, Packet::Data(packet) if matches!(packet.header, packet::DataHeader::Long(packet::long::DataHeader::Initial(..))))
                 }
 
-                let size = pkt.len();
                 let bind_uri = bind_uri.clone();
-                for (packet, way) in PacketReader::new(pkt, 8)
+                let packet_size = pkt.len();
+                for (received, way) in PacketReader::with_datagram_size(pkt, 8, datagram_size)
                     .flatten()
-                    .filter(move |pkt| !(is_initial_packet(pkt) && size < 1100))
-                    .map(move |pkt| (pkt, (bind_uri.clone(), route.pathway(), route.link())))
+                    .filter(move |(packet, _)| {
+                        !(is_initial_packet(packet) && packet_size < INITIAL_MINIMUM_PACKET_SIZE)
+                    })
+                    .map(move |received| {
+                        (received, (bind_uri.clone(), route.pathway(), route.link()))
+                    })
                 {
-                    quic_router.deliver(packet, way).await;
+                    quic_router.deliver(received, way).await;
                 }
             };
 
@@ -234,10 +245,11 @@ impl ReceiveAndDeliverPacketComponent {
                     };
 
                     // split_off forward header, deliver the rest as quic packet
+                    let datagram_size = pkt.len();
                     let pkt = pkt.split_off(ForwardHeader::encoding_size(&fhdr.pathway()));
                     route.seg_size = pkt.len() as _;
                     let new_route = Route::new(fhdr.pathway().flip().map(Into::into), route.line);
-                    deliver_quic_packet(pkt, new_route).await;
+                    deliver_quic_packet(pkt, new_route, datagram_size).await;
                     Ok(())
                 };
 
@@ -247,7 +259,10 @@ impl ReceiveAndDeliverPacketComponent {
                     for (pkt, hdr) in iface.recvmmsg(&mut bufs, &mut hdrs).await? {
                         match be_header(&pkt) {
                             // quic
-                            Err(_) => deliver_quic_packet(pkt, hdr).await,
+                            Err(_) => {
+                                let datagram_size = pkt.len();
+                                deliver_quic_packet(pkt, hdr, datagram_size).await
+                            }
                             // stun
                             Ok((_remain, Header::Stun(_stun_header))) => {
                                 deliver_stun_packet(pkt, hdr).await


### PR DESCRIPTION
## Summary

- account anti-amplification credit using the complete received UDP datagram payload rather than the parsed QUIC packet length
- keep UDP datagram metadata separate from QUIC packet types and count a coalesced datagram exactly once
- preserve forwarding-header accounting while naming and documenting the 1,100-byte stripped Initial threshold
- prepare `dquic` 0.7.0-beta.6 and the affected workspace crate releases
- pad direct PunchHello probes to 1,200 bytes so strict anti-amplification accounting can complete path validation

## Root cause

RFC 9000 Section 8.1 applies the anti-amplification limit to bytes received and sent in UDP datagrams. It is not limited to bytes covered by a QUIC Initial packet's Long Header Length field.

The receive path discarded the UDP datagram length after parsing and later credited the path with `PlainPacket::size()`. For the failing handshake, a 1,200-byte UDP datagram contained an Initial whose parsed packet length was about 290 bytes. The server therefore received only `290 * 3 = 870` bytes of credit instead of `1,200 * 3 = 3,600`.

The send path builds the Initial packet and then fills the remaining datagram buffer. Those bytes are UDP payload and consume anti-amplification credit even when they are outside that Initial packet's encoded Length.

## Why beta.4 appeared to work

beta.4 did not enforce the 870-byte balance correctly:

1. each segment assembler in a burst reread the same global credit before the batch was sent;
2. Initial assembly limited the encoded packet to the observed 870-byte credit, but the datagram buffer was still filled to 1,200 bytes;
3. `send_packets()` then deducted the actual 1,200 bytes from an `AtomicUsize` balance of 870 using `fetch_sub`.

That subtraction did not become negative. It wrapped modulo `usize`, leaving a balance near `usize::MAX`. The handshake progressed because receive undercounting was accidentally masked by oversending and unsigned wraparound, not because beta.4's accounting was correct.

## Why beta.5 exposed the issue

Commit `9fb85590` made credit addition/subtraction saturating and shared one remaining-credit budget across the whole burst. With the receive-side undercount still present, the server now genuinely had only 870 bytes available. The balance reached zero instead of wrapping, so the server could not produce the required minimum-size Initial datagram and the handshake stopped progressing. The h3x tests consequently timed out while waiting for the server SNI.

## Fix

`PacketReader` now returns each parsed packet together with its containing UDP datagram size. Only the first packet from a coalesced datagram carries a nonzero size, so the UDP bytes are credited once. Router, queue, and packet-space plumbing preserve this as `(packet, datagram_size)` rather than adding transport metadata to `DataPacket` or `CipherPacket`.

The path anti-amplification controller credits the complete datagram size. A new regression test models a roughly 290-byte Initial inside a 1,200-byte UDP datagram and verifies that it grants 3,600 bytes of credit rather than 870.

For qtraversal, the original UDP size is retained before removing `ForwardHeader`. The Initial filter still checks 1,100 bytes after header removal, now through a named constant with a comment explaining the reserved 100-byte forwarding-header budget.

RFC reference: https://www.rfc-editor.org/rfc/rfc9000.html#section-8.1

## Traversal failure exposed by strict accounting

The `punch` job exposed a second progress bug on newly discovered direct paths. qtraversal emitted a 34-byte PunchHello, which correctly gave the receiver only `34 * 3 = 102` bytes of anti-amplification credit. Instrumentation captured the full failure sequence:

1. receive a 34-byte PunchHello and increase credit from 0 to 102;
2. send one 102-byte PATH_CHALLENGE datagram and reduce credit to 0;
3. queue every later validation attempt with zero credit, so none reaches the network;
4. fail the direct path after the validation timeout.

RFC 9000 permits a PATH_CHALLENGE below 1,200 bytes when the anti-amplification limit prevents expansion, but that exchange does not validate the path MTU and leaves no useful loss tolerance during NAT hole creation. qtraversal now pads every PunchHello UDP payload to 1,200 bytes. The receiver therefore obtains 3,600 bytes of real credit, enough to send full-size path-validation datagrams and retransmit them without weakening the limit.

The unit test assembles and protects a real PunchHello packet and asserts a 1,200-byte UDP payload. The previously failing `full_cone_to_full_cone` case then passed in 10 consecutive fresh containers; three other observed failure combinations passed three fresh-container runs each.

RFC path-validation reference: https://www.rfc-editor.org/rfc/rfc9000.html#section-8.2.1

## Release

- `qbase` 0.6.2
- `qinterface` 0.7.0-beta.4
- `qtraversal` 0.7.0-beta.6
- `qconnection` 0.8.0-beta.3
- `dquic` 0.7.0-beta.6

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo publish --dry-run --locked -p qbase -p qinterface -p qtraversal -p qconnection -p dquic`
- `cargo test -p qtraversal punch_hello_funds_full_size_path_validation -- --nocapture`
- fresh-container traversal reproductions for the previously failing NAT combinations
- all three commits verified with valid SSH signatures

## Downstream impact

Consumers that directly use `PacketReader` or `QuicRouter` must carry `(Packet, datagram_size)`. The h3x custom network adapter has two call sites that need this mechanical API adaptation before adopting beta.6.
