### PR TITLE
fix(traversal): preserve draining routes and confirm direct paths

### DIFF
--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -764,19 +764,23 @@ mod tests {
         io,
         sync::{Arc, Once},
         task::{Context, Poll},
+        time::Duration,
     };
 
     use bytes::BytesMut;
     use qbase::{
+        cid::ConnectionId,
         error::ErrorKind,
         net::{
             addr::EndpointAddr,
             route::{Link, Route},
         },
+        packet::{LongHeaderBuilder, Packet},
         token::handy::NoopTokenRegistry,
     };
     use qinterface::{
         bind_uri::BindUri,
+        component::route::QuicRouter,
         io::{IO, ProductIO},
         manager::InterfaceManager,
     };
@@ -888,6 +892,17 @@ mod tests {
         }
     }
 
+    fn test_routed_packet(dcid: ConnectionId) -> Packet {
+        Packet::VN(LongHeaderBuilder::with_cid(dcid, ConnectionId::from_slice(b"scid")).vn(vec![1]))
+    }
+
+    async fn route_exists(router: &Arc<QuicRouter>, dcid: ConnectionId, way: Way) -> bool {
+        router
+            .try_deliver(test_routed_packet(dcid), way)
+            .await
+            .is_ok()
+    }
+
     #[tokio::test]
     async fn outbound_wildcard_path_preserves_the_io_owned_source() {
         let bind_uri: BindUri = "inet://0.0.0.0:50000".parse().unwrap();
@@ -919,6 +934,47 @@ mod tests {
 
         assert_eq!(path.link().src, local);
         assert!(!path.is_validated_for_test());
+    }
+
+    #[tokio::test]
+    async fn path_loss_retains_server_odcid_during_draining() {
+        let bind_uri: BindUri = "inet://127.0.0.1:50000".parse().unwrap();
+        let interfaces = Arc::new(InterfaceManager::new());
+        let _binding = interfaces
+            .bind(bind_uri.clone(), Arc::new(PendingTestIoFactory))
+            .await;
+        let router = Arc::new(QuicRouter::new());
+        let odcid = ConnectionId::from_slice(b"drain-odcid");
+        let connection = Connection::new_server(Arc::new(NoopTokenRegistry))
+            .with_tls_config(test_server_tls_config())
+            .with_iface_manager(interfaces)
+            .with_quic_router(router.clone())
+            .with_cids(odcid)
+            .run();
+        let local = "127.0.0.1:50000".parse().unwrap();
+        let remote = "127.0.0.1:4433".parse().unwrap();
+        let way = (
+            bind_uri,
+            Pathway::new(EndpointAddr::direct(local), EndpointAddr::direct(remote)),
+            Link::new(local, remote),
+        );
+
+        connection
+            .try_map_components(|components| components.get_or_try_create_path(way.clone(), false))
+            .expect("connection should remain active")
+            .expect("test path should be created");
+        connection.del_path(&way.1).unwrap();
+        tokio::task::yield_now().await;
+
+        assert_eq!(connection.conn_state.current(), Some(state::DRAINING));
+        assert!(route_exists(&router, odcid, way.clone()).await);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), connection.conn_state.closed())
+                .await
+                .is_err(),
+            "server ODCID route must survive the draining period"
+        );
+        assert!(route_exists(&router, odcid, way).await);
     }
 
     #[tokio::test]

--- a/qconnection/src/path/paths.rs
+++ b/qconnection/src/path/paths.rs
@@ -69,6 +69,7 @@ pub struct ArcPathContexts {
 struct State {
     accepting_paths: bool,
     initial_path: Option<Weak<Path>>,
+    last_path_pto: Option<Duration>,
 }
 
 impl ArcPathContexts {
@@ -80,6 +81,7 @@ impl ArcPathContexts {
             state: Arc::new(RwLock::new(State {
                 accepting_paths: true,
                 initial_path: None,
+                last_path_pto: None,
             })),
         }
     }
@@ -177,15 +179,20 @@ impl ArcPathContexts {
     }
 
     pub fn remove(&self, pathway: &Pathway, reason: &PathDeactivated) {
-        if self.paths.remove(pathway).is_some() {
-            tracing::debug!(target: "dquic", %pathway, %reason, "path deactivated");
-            if self.state.read().unwrap().accepting_paths && self.is_empty() {
-                let error = QuicError::with_default_fty(
-                    ErrorKind::NoViablePath,
-                    format!("No viable path exist, last path removed because: {reason}"),
-                );
-                self.broker.emit(Event::Failed(error));
-            }
+        let Some((_, path)) = self.paths.remove(pathway) else {
+            return;
+        };
+        tracing::debug!(target: "dquic", %pathway, %reason, "path deactivated");
+
+        let mut state = self.state.write().unwrap();
+        if state.accepting_paths && self.is_empty() {
+            state.last_path_pto = Some(path.cc().get_pto(Epoch::Data));
+            let error = QuicError::with_default_fty(
+                ErrorKind::NoViablePath,
+                format!("No viable path exist, last path removed because: {reason}"),
+            );
+            drop(state);
+            self.broker.emit(Event::Failed(error));
         }
     }
 
@@ -194,7 +201,11 @@ impl ArcPathContexts {
     }
 
     pub fn max_pto_duration(&self) -> Option<Duration> {
-        self.paths.iter().map(|p| p.cc().get_pto(Epoch::Data)).max()
+        self.paths
+            .iter()
+            .map(|p| p.cc().get_pto(Epoch::Data))
+            .max()
+            .or_else(|| self.state.read().unwrap().last_path_pto)
     }
 
     pub fn paths<C: FromIterator<(Pathway, Arc<Path>)>>(&self) -> C {

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -191,13 +191,19 @@ const KNOCK_TIMEOUT: Duration = Duration::from_millis(100);
 const PUNCH_TIMEOUT: Duration = Duration::from_secs(3);
 const PUNCH_ME_NOW_TIMEOUT: Duration = Duration::from_secs(1);
 const COLLISION_TIMEOUT: Duration = Duration::from_secs(3);
+const PUNCH_DONE_CONFIRM_INTERVAL: Duration = Duration::from_millis(30);
 // Birthday attack timeout: must exceed PortPredictor's full run time (~6s for 300 probes × 20ms)
 const BIRTHDAY_TIMEOUT: Duration = Duration::from_secs(8);
 
 // Quantity
 const MAX_RETRIES: usize = 5;
+const PUNCH_DONE_CONFIRM_RETRIES: usize = 3;
 const COLLISION_PORTS: u32 = 800;
 const PUNCHER_LOCAL_SHARDS: usize = 2;
+
+fn direct_punch_done_response(link: Link, hello: &PunchHelloFrame) -> (Link, PunchDoneFrame) {
+    (link, PunchDoneFrame::respond_to(hello))
+}
 
 pub struct ArcPuncher<TX, PH, S>(Arc<Puncher<TX, PH, S>>);
 
@@ -334,6 +340,25 @@ where
         iface
             .sendmmsg(&[io::IoSlice::new(&buffer[..sent_bytes])], route)
             .await
+    }
+
+    async fn send_direct_punch_done_with_retry(
+        &self,
+        iface: &(impl IO + ?Sized),
+        link: Link,
+        frame: PunchDoneFrame,
+    ) where
+        PunchDoneFrame: for<'b> Package<S::PacketAssembler<'b>>,
+        PadTo20: for<'b> Package<S::PacketAssembler<'b>>,
+    {
+        for attempt in 0..PUNCH_DONE_CONFIRM_RETRIES {
+            if let Err(error) = self.send_packet(iface, link, HELLO_TTL, frame).await {
+                tracing::debug!(target: "punch", %link, ?error, "failed to send direct PunchDone confirmation");
+            }
+            if attempt + 1 < PUNCH_DONE_CONFIRM_RETRIES {
+                tokio::time::sleep(PUNCH_DONE_CONFIRM_INTERVAL).await;
+            }
+        }
     }
 
     async fn collision(
@@ -1760,10 +1785,30 @@ where
 
     fn recv_frame(
         &self,
-        (_bind, pathway, link, frame): (BindUri, Pathway, Link, PunchHelloFrame),
+        (bind, pathway, link, frame): (BindUri, Pathway, Link, PunchHelloFrame),
     ) -> Result<Self::Output, qbase::error::Error> {
         tracing::debug!(target: "punch", %pathway, %link, frame = ?frame, "received punch hello frame");
         let punch_id = frame.punch_id().flip();
+
+        // A broker confirmation alone does not prove that the peer can receive on this path.
+        // Reply on the observed link so simultaneous active punches establish path evidence at
+        // both endpoints even if one side's first Hello arrived before the NAT hole was open.
+        if let Some(iface) = self.0.ifaces.borrow(&bind) {
+            let puncher = self.0.clone();
+            let (response_link, response_frame) = direct_punch_done_response(link, &frame);
+            tokio::spawn(
+                async move {
+                    puncher
+                        .send_direct_punch_done_with_retry(&iface, response_link, response_frame)
+                        .await;
+                }
+                .instrument_in_current()
+                .in_current_span(),
+            );
+        } else {
+            tracing::debug!(target: "punch", %bind, %link, %punch_id, "cannot send direct PunchDone without interface");
+        }
+
         match self.0.transaction.entry(punch_id) {
             Entry::Occupied(mut entry) => {
                 let tx = entry.get_mut().1.clone();
@@ -1842,6 +1887,22 @@ async fn dynamic_iface(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn simultaneous_active_punch_confirms_on_the_observed_link() {
+        let link = Link::new(
+            "192.0.2.10:50000".parse().unwrap(),
+            "198.51.100.20:60000".parse().unwrap(),
+        );
+        let hello = PunchHelloFrame::new(7, 11, 13);
+
+        let (response_link, response) = direct_punch_done_response(link, &hello);
+
+        assert_eq!(response_link, link);
+        assert_eq!(response.local_seq(), 11);
+        assert_eq!(response.remote_seq(), 7);
+        assert_eq!(response.probe_id(), 13);
+    }
 
     #[test]
     fn direct_pairing_rejects_loopback_to_non_loopback() {


### PR DESCRIPTION
## 问题

- 最后一条路径移除后，draining 时间被错误计算为 0，服务端立即删除 ODCID 路由。迟到的旧 Initial 因此创建了新连接，并出现 `ACK largest > largest sent`。
- 双端同时打洞时，收到 direct `PunchHello` 后只通过 broker 回复，可能导致直连路径只在一端建立。

## 修复

- 缓存最后一条路径的 Data PTO，在路径表为空时仍保留 ODCID 路由三个 PTO。
- 收到 direct `PunchHello` 后，沿实际收到报文的 Link 重试三次 direct `PunchDone`。
- 增加 ODCID 路由保留和直连回复的回归测试。

## 验证

- 精确打洞案例独立运行 20/20 通过。
- 完整 25 组 NAT 打洞测试通过。
- workspace tests、clippy、fmt 和 GitHub CI 全部通过。
- 两个提交均有签名并通过 GitHub 验证。

本 PR 独立于 #735。