### PR TITLE
fix(qtraversal): recover stun after rebind

### DIFF
--- a/dquic/src/client.rs
+++ b/dquic/src/client.rs
@@ -542,6 +542,7 @@ impl QuicClient {
 }
 
 impl<T> QuicClientBuilder<T> {
+    /// Configure the resolver used for connection target names.
     pub fn with_resolver(mut self, resolver: Arc<dyn Resolve + Send + Sync>) -> Self {
         self.network.resolver = resolver;
         self

--- a/dquic/src/common.rs
+++ b/dquic/src/common.rs
@@ -1,4 +1,4 @@
-use std::{iter, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use futures::{Stream, stream::FuturesUnordered};
 use qconnection::{
@@ -17,7 +17,7 @@ use qconnection::{
         manager::InterfaceManager,
     },
     qtraversal::{
-        nat::{client::StunClientsComponent, router::StunRouterComponent},
+        nat::{client::StunClientComponent, router::StunRouterComponent},
         route::{ForwardersComponent, ReceiveAndDeliverPacketComponent},
     },
 };
@@ -73,14 +73,14 @@ impl Network {
                         .router();
                     // STUN bootstrap names use system DNS.
                     let stun_server = stun_server.clone();
-                    let clients = components
+                    let stun_client = components
                         .init_with(|| {
-                            StunClientsComponent::new(
+                            StunClientComponent::new(
                                 iface.downgrade(),
                                 stun_router.clone(),
                                 Arc::new(SystemResolver),
                                 stun_server,
-                                iter::empty(),
+                                None,
                                 Some(local_endpoints.clone()),
                             )
                         })
@@ -97,7 +97,7 @@ impl Network {
                             .forwarder()
                     } else {
                         components
-                            .init_with(|| ForwardersComponent::new_client(clients))
+                            .init_with(|| ForwardersComponent::new_client(stun_client))
                             .forwarder()
                     };
 

--- a/dquic/src/common.rs
+++ b/dquic/src/common.rs
@@ -71,14 +71,14 @@ impl Network {
                     let stun_router = components
                         .init_with(|| StunRouterComponent::new(iface.downgrade()))
                         .router();
-                    // initial stun clients (DNS is resolved once by a background task)
+                    // STUN bootstrap names use system DNS.
                     let stun_server = stun_server.clone();
                     let clients = components
                         .init_with(|| {
                             StunClientsComponent::new(
                                 iface.downgrade(),
                                 stun_router.clone(),
-                                self.resolver.clone(),
+                                Arc::new(SystemResolver),
                                 stun_server,
                                 iter::empty(),
                                 Some(local_endpoints.clone()),
@@ -131,8 +131,8 @@ impl Network {
             self.stun_server.clone()
         };
 
-        // STUN agent DNS resolution runs once in StunClientsComponent's background task.
-        // Binding itself never waits for DNS.
+        // STUN agent discovery and interface readiness are retried in the background.
+        // Binding itself never waits for DNS or a usable local address.
 
         let factory = self.iface_factory.clone();
         let bind_iface = self.iface_manager.bind(bind_uri, factory).await;

--- a/dquic/tests/traversal.rs
+++ b/dquic/tests/traversal.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    io,
     net::SocketAddr,
     sync::{Arc, LazyLock},
     time::Duration,
@@ -10,14 +9,13 @@ use dquic::{
     prelude::{handy::*, *},
     qinterface::{component::local_endpoint::LocalEndpoints, manager::InterfaceManager},
     qresolve::Source,
-    qtraversal::nat::client::{NatType, StunClientsComponent},
+    qtraversal::nat::client::{NatType, StunClientComponent},
 };
 use futures::{
     FutureExt,
     future::{BoxFuture, Shared},
 };
 use rustls::RootCertStore;
-use tokio::task::JoinSet;
 use tracing::{info, warn};
 
 mod common;
@@ -256,47 +254,33 @@ async fn test_punch_case(client_nat: NatType, server_nat: NatType) {
         .borrow(&(server_case.bind_addr.parse::<SocketAddr>().unwrap().into()))
         .unwrap();
 
-    let server_ep = get_stun_data(server_iface).await[0].0;
+    let server_ep = get_stun_data(server_iface).await.0;
     launch_client(client_case, server_ep).await;
 }
 
 const STUN_DATA_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const STUN_DATA_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-async fn get_stun_data(server_iface: dquic::qinterface::Interface) -> Vec<(EndpointAddr, NatType)> {
+async fn get_stun_data(server_iface: dquic::qinterface::Interface) -> (EndpointAddr, NatType) {
     let deadline = tokio::time::Instant::now() + STUN_DATA_WAIT_TIMEOUT;
 
     loop {
-        let mut outer_addresses = server_iface
-            .with_component(|clients: &StunClientsComponent| {
-                clients.with_clients(|clients| {
-                    // workaround. clippy issue: https://github.com/rust-lang/rust-clippy/issues/16428
-                    #[allow(clippy::redundant_iter_cloned)]
-                    clients
-                        .values()
-                        .cloned()
-                        .map(|client| async move {
-                            let agent = client.agent_addr();
-                            let outer = client.outer_addr().await?;
-                            let ep = EndpointAddr::with_agent(agent, outer);
-                            let nat_type = client.nat_type().await?;
-                            io::Result::Ok((ep, nat_type))
-                        })
-                        .collect::<JoinSet<_>>()
-                })
+        let client = server_iface
+            .with_component(|component: &StunClientComponent| {
+                component.with_client(|client| client.cloned())
             })
             .expect("interface rebinded too quickly")
             .expect("traversal components missing");
-        let mut datas = vec![];
 
-        while let Some(join_result) = outer_addresses.join_next().await {
-            let result = join_result.expect("detect panic");
-            let data = result.expect("detect outer addr or nat type failed");
-            datas.push(data);
-        }
-
-        if !datas.is_empty() {
-            return datas;
+        if let Some(client) = client {
+            let agent = client.agent_addr();
+            let outer = client
+                .outer_addr()
+                .await
+                .expect("failed to detect outer address");
+            let endpoint = EndpointAddr::with_agent(agent, outer);
+            let nat_type = client.nat_type().await.expect("failed to detect NAT type");
+            return (endpoint, nat_type);
         }
 
         let now = tokio::time::Instant::now();

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -29,7 +29,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }
-tokio = { features = ["fs", "rt-multi-thread"], workspace = true }
+tokio = { features = ["fs", "rt-multi-thread", "test-util"], workspace = true }
 
 [dev-dependencies.tracing-subscriber]
 workspace = true

--- a/qtraversal/src/nat/client.rs
+++ b/qtraversal/src/nat/client.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt};
-use qbase::net::{Family, addr::EndpointAddr};
+use qbase::net::{AddrFamily, Family, addr::EndpointAddr};
 pub use qbase::net::{NatType, NetFeature};
 use qinterface::{
     Interface, WeakInterface,
@@ -28,7 +28,7 @@ use qinterface::{
 };
 use qresolve::Resolve;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::task::JoinSet;
+use tokio::{sync::Notify, task::JoinSet, time::Instant};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Instrument;
 
@@ -44,6 +44,40 @@ use crate::{
 
 const NAT_MAPPING_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const MAX_STUN_AGENTS: usize = 3;
+const STUN_AGENT_DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
+const STUN_DISCOVERY_RETRY_INITIAL: Duration = Duration::from_secs(1);
+const STUN_DISCOVERY_RETRY_MAX: Duration = Duration::from_secs(300);
+const STUN_PROBE_RETRY_INITIAL: Duration = Duration::from_secs(1);
+const STUN_PROBE_RETRY_MAX: Duration = Duration::from_secs(300);
+const STUN_ENDPOINT_FAILURE_GRACE_PERIOD: Duration = Duration::from_secs(60);
+
+fn retry_delay(retry_interval: &mut Duration, max: Duration) -> Duration {
+    let delay = *retry_interval;
+    *retry_interval = (*retry_interval * 2).min(max);
+    delay
+}
+
+fn stun_probe_delay(probe_succeeded: bool, retry_interval: &mut Duration) -> Duration {
+    if probe_succeeded {
+        *retry_interval = STUN_PROBE_RETRY_INITIAL;
+        NAT_MAPPING_REFRESH_INTERVAL
+    } else {
+        retry_delay(retry_interval, STUN_PROBE_RETRY_MAX)
+    }
+}
+
+fn retain_last_stun_endpoint(last_success: Option<Instant>, now: Instant) -> bool {
+    last_success.is_some_and(|last_success| {
+        now.saturating_duration_since(last_success) < STUN_ENDPOINT_FAILURE_GRACE_PERIOD
+    })
+}
+
+fn stun_interface_ready<I: RefIO>(ref_iface: &I, family: Family) -> bool {
+    ref_iface
+        .iface()
+        .bound_addr()
+        .is_ok_and(|bound_addr| bound_addr.family() == family)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NatDetectionStep {
@@ -134,6 +168,112 @@ impl From<DetectOuterAddrError> for io::Error {
     }
 }
 
+struct StunKeepAliveState {
+    outer_addr: Arc<Future<Result<SocketAddr, DetectOuterAddrError>>>,
+    endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
+    outer_addr_ready: Arc<Notify>,
+    publish_endpoint: bool,
+    retry_interval: Duration,
+    last_success: Option<Instant>,
+}
+
+impl StunKeepAliveState {
+    fn new(
+        outer_addr: Arc<Future<Result<SocketAddr, DetectOuterAddrError>>>,
+        endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
+        outer_addr_ready: Arc<Notify>,
+        publish_endpoint: bool,
+    ) -> Self {
+        Self {
+            outer_addr,
+            endpoint_publisher,
+            outer_addr_ready,
+            publish_endpoint,
+            retry_interval: STUN_PROBE_RETRY_INITIAL,
+            last_success: None,
+        }
+    }
+
+    fn apply(&mut self, detect_result: Result<SocketAddr, DetectOuterAddrError>) -> Duration {
+        self.log_result(&detect_result);
+
+        let now = Instant::now();
+        let delay = stun_probe_delay(detect_result.is_ok(), &mut self.retry_interval);
+        let retain_previous =
+            detect_result.is_err() && retain_last_stun_endpoint(self.last_success, now);
+
+        if self.publish_endpoint && !retain_previous {
+            self.publish_result(&detect_result);
+        }
+
+        match detect_result {
+            Ok(outer) => {
+                self.last_success = Some(now);
+                self.outer_addr.assign(Ok(outer));
+                self.outer_addr_ready.notify_waiters();
+            }
+            Err(_) if retain_previous => {
+                tracing::debug!(
+                    target: "stun",
+                    grace_ms = STUN_ENDPOINT_FAILURE_GRACE_PERIOD.as_millis(),
+                    "retaining last STUN endpoint after transient probe failure"
+                );
+            }
+            Err(error) => {
+                if self.last_success.take().is_some() {
+                    tracing::debug!(
+                        target: "stun",
+                        "withdrawing STUN endpoint after failure grace period"
+                    );
+                }
+                self.outer_addr.assign(Err(error));
+            }
+        }
+
+        delay
+    }
+
+    fn log_result(&self, detect_result: &Result<SocketAddr, DetectOuterAddrError>) {
+        match detect_result {
+            Ok(new_outer_addr) => match self.outer_addr.try_get().as_deref().cloned() {
+                Some(Ok(old_outer)) if old_outer == *new_outer_addr => {
+                    tracing::trace!(target: "stun", %new_outer_addr, "keep alive, outer addr unchanged");
+                }
+                Some(Ok(old_outer)) => {
+                    tracing::debug!(target: "stun", %old_outer, %new_outer_addr, "keep alive, outer addr changed");
+                }
+                Some(Err(error)) => {
+                    tracing::debug!(
+                        target: "stun",
+                        error = %snafu::Report::from_error(&error),
+                        %new_outer_addr,
+                        "outer addr detection recovered"
+                    );
+                }
+                None => {
+                    tracing::debug!(target: "stun", %new_outer_addr, "detected outer addr");
+                }
+            },
+            Err(error) => {
+                tracing::trace!(target: "stun", error = %snafu::Report::from_error(error), "detect outer addr failed");
+            }
+        }
+    }
+
+    fn publish_result(&self, detect_result: &Result<SocketAddr, DetectOuterAddrError>) {
+        let mut guard = self
+            .endpoint_publisher
+            .lock()
+            .expect("STUN endpoint publisher mutex poisoned");
+        if let Some(publisher) = guard.as_mut() {
+            match detect_result {
+                Ok(outer) => publisher.upsert(*outer),
+                Err(_) => publisher.remove(),
+            };
+        }
+    }
+}
+
 #[derive(Debug, Clone, Snafu)]
 #[snafu(module)]
 pub enum DetectNatTypeError {
@@ -176,6 +316,7 @@ pub struct StunClient<I: RefIO + 'static> {
     stun_router: StunRouter,
     stun_agent: SocketAddr,
     endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
+    outer_addr_ready: Arc<Notify>,
 
     closing: Arc<AtomicBool>,
     tasks: Arc<Mutex<JoinSet<()>>>,
@@ -204,6 +345,7 @@ impl<I: RefIO + 'static> StunClient<I> {
             ref_iface,
             stun_router,
             endpoint_publisher: Arc::new(Mutex::new(endpoint_publisher)),
+            outer_addr_ready: Arc::new(Notify::new()),
             closing: Arc::new(AtomicBool::new(false)),
             tasks: Arc::new(Mutex::new(JoinSet::new())),
         };
@@ -223,42 +365,20 @@ impl<I: RefIO + 'static> StunClient<I> {
     }
 
     fn keep_alive_task(&self) -> impl futures::Future<Output = ()> + use<I> {
-        let outer_addr = self.outer_addr.clone();
         let stun_agent = self.stun_agent;
         let stun_router = self.stun_router.clone();
         tracing::debug!(target: "stun", %stun_agent, "starting STUN client keep alive task");
         let ref_iface = self.ref_iface.clone();
         let bind_uri = ref_iface.iface().bind_uri();
 
-        let endpoint_publisher = self.endpoint_publisher.clone();
+        let mut state = StunKeepAliveState::new(
+            self.outer_addr.clone(),
+            self.endpoint_publisher.clone(),
+            self.outer_addr_ready.clone(),
+            !bind_uri.is_temporary(),
+        );
 
         let keep_alive_task = async move {
-            let log_detect_result = |detect_result: &Result<SocketAddr, DetectOuterAddrError>| {
-                match &detect_result {
-                    Ok(new_outer_addr) => match outer_addr.try_get().as_deref().cloned() {
-                        Some(Ok(old_outer)) if old_outer == *new_outer_addr => {
-                            tracing::trace!(target: "stun", %new_outer_addr,  "keep alive, outer addr unchanged");
-                        }
-                        Some(Ok(old_outer)) => {
-                            tracing::debug!(target: "stun", %old_outer, %new_outer_addr, "keep alive, outer addr changed");
-                        }
-                        Some(Err(error)) => {
-                            tracing::debug!(
-                                target: "stun",
-                                error = %snafu::Report::from_error(&error),
-                                %new_outer_addr,
-                                "outer addr detection recovered"
-                            );
-                        }
-                        None => {
-                            tracing::debug!(target: "stun", %new_outer_addr, "detected outer addr");
-                        }
-                    },
-                    Err(error) => {
-                        tracing::trace!(target: "stun", error = %snafu::Report::from_error(error), "detect outer addr failed");
-                    }
-                }
-            };
             tracing::trace!(target: "stun", "starting keep alive task");
             loop {
                 let detect_result = detect_outer_addr(
@@ -269,32 +389,8 @@ impl<I: RefIO + 'static> StunClient<I> {
                     Duration::from_millis(300),
                 )
                 .await;
-
-                log_detect_result(&detect_result);
-
-                let timeout = match &detect_result {
-                    Ok(_) => NAT_MAPPING_REFRESH_INTERVAL,
-                    Err(_) => Duration::from_secs(1),
-                };
-
-                if !bind_uri.is_temporary() {
-                    let mut guard = endpoint_publisher
-                        .lock()
-                        .expect("STUN endpoint publisher mutex poisoned");
-                    if let Some(publisher) = guard.as_mut() {
-                        match &detect_result {
-                            Ok(outer) => {
-                                publisher.upsert(*outer);
-                            }
-                            Err(_) => {
-                                publisher.remove();
-                            }
-                        }
-                    }
-                }
-
-                outer_addr.assign(detect_result);
-                tokio::time::sleep(timeout).await;
+                let delay = state.apply(detect_result);
+                tokio::time::sleep(delay).await;
             }
         };
         let bind_uri = self.ref_iface.iface().bind_uri();
@@ -338,6 +434,8 @@ impl<I: RefIO + 'static> StunClient<I> {
 
     fn nat_detect_task(&self) -> impl futures::Future<Output = ()> + use<I> {
         let nat_type = self.nat_type.clone();
+        let outer_addr = self.outer_addr.clone();
+        let outer_addr_ready = self.outer_addr_ready.clone();
         let ref_iface = self.ref_iface.clone();
         let stun_router = self.stun_router.clone();
         let stun_agent = self.stun_agent;
@@ -345,6 +443,13 @@ impl<I: RefIO + 'static> StunClient<I> {
         // Note: 原来的逻辑是 nat 探测会新建 iface，但是有的服务器只能开放指定端口，所以还是用监听的端口进行探测
         // 又因为Dynamic 总是会新建 iface 进行打洞，所以这里污染了影响不会很大
         let task = async move {
+            loop {
+                let notified = outer_addr_ready.notified();
+                if outer_addr.try_get().as_deref().is_some_and(Result::is_ok) {
+                    break;
+                }
+                notified.await;
+            }
             tracing::debug!(target: "stun", "starting NAT type detection");
             // NAT classification uses changed-address responses that may
             // traverse another STUN server and Docker/router conntrack before
@@ -478,21 +583,15 @@ async fn resolve_stun_agents(
     resolver: &(dyn Resolve + Send + Sync),
     server: &str,
     family: Family,
-) -> Vec<SocketAddr> {
-    let Ok(mut records) = resolver.lookup(server).await else {
-        return Vec::new();
-    };
+) -> io::Result<Vec<SocketAddr>> {
+    let mut records = resolver.lookup(server).await?;
     let mut agents = Vec::with_capacity(MAX_STUN_AGENTS);
 
     while let Some((_, endpoint)) = records.next().await {
         let EndpointAddr::Direct { addr } = endpoint else {
             continue;
         };
-        let matches_family = match family {
-            Family::V4 => addr.is_ipv4(),
-            Family::V6 => addr.is_ipv6(),
-        };
-        if matches_family && !agents.contains(&addr) {
+        if addr.family() == family && !agents.contains(&addr) {
             agents.push(addr);
             if agents.len() == MAX_STUN_AGENTS {
                 break;
@@ -500,7 +599,110 @@ async fn resolve_stun_agents(
         }
     }
 
-    agents
+    Ok(agents)
+}
+
+async fn lookup_stun_agents(
+    resolver: &(dyn Resolve + Send + Sync),
+    server: &str,
+    family: Family,
+) -> Option<Vec<SocketAddr>> {
+    match tokio::time::timeout(
+        STUN_AGENT_DNS_LOOKUP_TIMEOUT,
+        resolve_stun_agents(resolver, server, family),
+    )
+    .await
+    {
+        Ok(Ok(discovered)) if !discovered.is_empty() => Some(discovered),
+        Ok(Ok(_)) => {
+            tracing::debug!(
+                target: "stun",
+                %server,
+                ?family,
+                "STUN agent lookup returned no compatible addresses"
+            );
+            None
+        }
+        Ok(Err(error)) => {
+            tracing::debug!(
+                target: "stun",
+                %server,
+                ?family,
+                ?error,
+                "failed to resolve STUN agents; retrying"
+            );
+            None
+        }
+        Err(_) => {
+            tracing::debug!(
+                target: "stun",
+                %server,
+                ?family,
+                timeout_ms = STUN_AGENT_DNS_LOOKUP_TIMEOUT.as_millis(),
+                "STUN agent lookup timed out; retrying"
+            );
+            None
+        }
+    }
+}
+
+async fn wait_for_stun_interface<I: RefIO>(ref_iface: &I, family: Family) {
+    let mut retry_interval = STUN_DISCOVERY_RETRY_INITIAL;
+    while !stun_interface_ready(ref_iface, family) {
+        tracing::trace!(
+            target: "stun",
+            bind_uri = %ref_iface.iface().bind_uri(),
+            ?family,
+            "STUN discovery dormant until the interface has a local address"
+        );
+        tokio::time::sleep(retry_delay(&mut retry_interval, STUN_DISCOVERY_RETRY_MAX)).await;
+    }
+}
+
+async fn discover_stun_agents(
+    resolver: &(dyn Resolve + Send + Sync),
+    server: &str,
+    family: Family,
+) -> Vec<SocketAddr> {
+    let mut retry_interval = STUN_DISCOVERY_RETRY_INITIAL;
+    loop {
+        if let Some(discovered) = lookup_stun_agents(resolver, server, family).await {
+            return discovered;
+        }
+        tokio::time::sleep(retry_delay(&mut retry_interval, STUN_DISCOVERY_RETRY_MAX)).await;
+    }
+}
+
+fn refresh_stun_clients<I, F>(
+    clients: &Mutex<StunClientsMap<I>>,
+    discovered: Vec<SocketAddr>,
+    new_stun_client: F,
+) -> Vec<StunClient<I>>
+where
+    I: RefIO + 'static,
+    F: Fn(SocketAddr) -> StunClient<I>,
+{
+    let mut clients = clients.lock().expect("StunClients mutex poisoned");
+    let mut refreshed = HashMap::with_capacity(discovered.len());
+    for agent in discovered {
+        let client = clients
+            .remove(&agent)
+            .unwrap_or_else(|| new_stun_client(agent));
+        refreshed.insert(agent, client);
+    }
+
+    let stale_clients = clients
+        .drain()
+        .map(|(_, client)| client)
+        .collect::<Vec<_>>();
+    *clients = refreshed;
+    stale_clients
+}
+
+async fn close_stun_clients<I: RefIO + 'static>(clients: Vec<StunClient<I>>) {
+    for client in clients {
+        core::future::poll_fn(|cx| client.poll_close(cx)).await;
+    }
 }
 
 #[derive(Debug)]
@@ -523,52 +725,57 @@ impl<I: RefIO + 'static> StunClientsInner<I> {
         agents: impl IntoIterator<Item = SocketAddr>,
         local_endpoints: Option<IfaceLocalEndpoints<I>>,
     ) -> Self {
+        let family = ref_iface.iface().bind_uri().family();
+        let interface_ready = stun_interface_ready(&ref_iface, family);
         let new_stun_client = {
             let ref_iface = ref_iface.clone();
             move |agent_addr: SocketAddr| {
-                let local_addr = ref_iface.iface().local_addr().ok()?;
-                if local_addr.is_ipv4() != agent_addr.is_ipv4() {
-                    return None;
-                }
                 let stun_router = router.clone();
-                Some(StunClient::new(
+                StunClient::new(
                     ref_iface.clone(),
                     stun_router,
                     agent_addr,
                     local_endpoints.clone(),
-                ))
+                )
             }
         };
 
-        let clients: Arc<Mutex<StunClientsMap<I>>> = Arc::new(Mutex::new(
-            agents
-                .into_iter()
-                .filter_map(|agent| {
-                    tracing::trace!(target: "stun", %agent, "initializing STUN client for agent");
-                    new_stun_client(agent).map(|client| (agent, client))
-                })
-                .collect(),
-        ));
+        let mut known_agents = Vec::with_capacity(MAX_STUN_AGENTS);
+        for agent in agents {
+            if known_agents.len() == MAX_STUN_AGENTS {
+                break;
+            }
+            if agent.family() == family && !known_agents.contains(&agent) {
+                known_agents.push(agent);
+            }
+        }
+        let mut initial_clients = HashMap::new();
+        if interface_ready {
+            for agent in &known_agents {
+                initial_clients.insert(*agent, new_stun_client(*agent));
+            }
+        }
+        let clients: Arc<Mutex<StunClientsMap<I>>> = Arc::new(Mutex::new(initial_clients));
         let task = AbortOnDropHandle::new(tokio::spawn({
             let clients = clients.clone();
+            let ref_iface = ref_iface.clone();
             let resolver = resolver.clone();
             let server = server.clone();
-            let family = ref_iface.iface().bind_uri().family();
             async move {
-                for addr in resolve_stun_agents(resolver.as_ref(), server.as_ref(), family).await {
-                    let mut clients = clients.lock().expect("StunClients mutex poisoned");
-                    if clients.len() >= MAX_STUN_AGENTS {
-                        break;
-                    }
-                    if clients.contains_key(&addr) {
-                        continue;
-                    }
-                    let Some(client) = new_stun_client(addr) else {
-                        continue;
-                    };
-                    tracing::debug!(target: "stun", %addr, "discovered new STUN agent");
-                    clients.insert(addr, client);
+                wait_for_stun_interface(&ref_iface, family).await;
+
+                if !interface_ready {
+                    let stale_clients =
+                        refresh_stun_clients(&clients, known_agents, &new_stun_client);
+                    close_stun_clients(stale_clients).await;
                 }
+
+                let discovered =
+                    discover_stun_agents(resolver.as_ref(), server.as_ref(), family).await;
+                let stale_clients = refresh_stun_clients(&clients, discovered, new_stun_client);
+                close_stun_clients(stale_clients).await;
+                let count = clients.lock().expect("StunClients mutex poisoned").len();
+                tracing::debug!(target: "stun", count, "installed STUN clients");
             }
             .in_current_span()
         }));
@@ -669,15 +876,16 @@ impl Component for StunClientsComponent {
                 local_endpoints.clone()
             });
 
-            let new_clinets = StunClientsInner::new(
+            let known_agents = clients.lock_clients().keys().copied().collect::<Vec<_>>();
+            let new_clients = StunClientsInner::new(
                 iface.downgrade(),
                 router,
                 clients.resolver.clone(),
                 clients.server.clone(),
-                std::iter::empty(),
+                known_agents,
                 local_endpoints,
             );
-            *clients = new_clinets;
+            *clients = new_clients;
         });
     }
 }

--- a/qtraversal/src/nat/client.rs
+++ b/qtraversal/src/nat/client.rs
@@ -1,9 +1,7 @@
 use std::{
-    collections::HashMap,
     fmt,
     io::{self},
     net::SocketAddr,
-    ops::Deref,
     sync::{
         Arc, Mutex, MutexGuard,
         atomic::{AtomicBool, Ordering::SeqCst},
@@ -43,7 +41,6 @@ use crate::{
 };
 
 const NAT_MAPPING_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
-const MAX_STUN_AGENTS: usize = 3;
 const STUN_AGENT_DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
 const STUN_DISCOVERY_RETRY_INITIAL: Duration = Duration::from_secs(1);
 const STUN_DISCOVERY_RETRY_MAX: Duration = Duration::from_secs(300);
@@ -172,6 +169,7 @@ struct StunKeepAliveState {
     outer_addr: Arc<Future<Result<SocketAddr, DetectOuterAddrError>>>,
     endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
     outer_addr_ready: Arc<Notify>,
+    refresh_agent: Arc<Notify>,
     publish_endpoint: bool,
     retry_interval: Duration,
     last_success: Option<Instant>,
@@ -182,12 +180,14 @@ impl StunKeepAliveState {
         outer_addr: Arc<Future<Result<SocketAddr, DetectOuterAddrError>>>,
         endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
         outer_addr_ready: Arc<Notify>,
+        refresh_agent: Arc<Notify>,
         publish_endpoint: bool,
     ) -> Self {
         Self {
             outer_addr,
             endpoint_publisher,
             outer_addr_ready,
+            refresh_agent,
             publish_endpoint,
             retry_interval: STUN_PROBE_RETRY_INITIAL,
             last_success: None,
@@ -220,6 +220,12 @@ impl StunKeepAliveState {
                 );
             }
             Err(error) => {
+                let refresh_agent = matches!(
+                    &error,
+                    DetectOuterAddrError::Probe {
+                        source: StunProbeError::NoResponse { .. }
+                    } | DetectOuterAddrError::Response { .. }
+                );
                 if self.last_success.take().is_some() {
                     tracing::debug!(
                         target: "stun",
@@ -227,6 +233,9 @@ impl StunKeepAliveState {
                     );
                 }
                 self.outer_addr.assign(Err(error));
+                if refresh_agent {
+                    self.refresh_agent.notify_one();
+                }
             }
         }
 
@@ -317,6 +326,7 @@ pub struct StunClient<I: RefIO + 'static> {
     stun_agent: SocketAddr,
     endpoint_publisher: Arc<Mutex<Option<InterfaceAgentEndpointPublisher>>>,
     outer_addr_ready: Arc<Notify>,
+    refresh_agent: Arc<Notify>,
 
     closing: Arc<AtomicBool>,
     tasks: Arc<Mutex<JoinSet<()>>>,
@@ -346,6 +356,7 @@ impl<I: RefIO + 'static> StunClient<I> {
             stun_router,
             endpoint_publisher: Arc::new(Mutex::new(endpoint_publisher)),
             outer_addr_ready: Arc::new(Notify::new()),
+            refresh_agent: Arc::new(Notify::new()),
             closing: Arc::new(AtomicBool::new(false)),
             tasks: Arc::new(Mutex::new(JoinSet::new())),
         };
@@ -375,6 +386,7 @@ impl<I: RefIO + 'static> StunClient<I> {
             self.outer_addr.clone(),
             self.endpoint_publisher.clone(),
             self.outer_addr_ready.clone(),
+            self.refresh_agent.clone(),
             !bind_uri.is_temporary(),
         );
 
@@ -501,12 +513,7 @@ impl<I: RefIO + 'static> StunClient<I> {
     //     Ok(())
     // }
 
-    pub fn poll_close(&self, cx: &mut Context) -> Poll<()> {
-        if self.closing.swap(true, SeqCst) {
-            return Poll::Ready(());
-        }
-        self.lock_tasks().abort_all();
-        while ready!(self.lock_tasks().poll_join_next(cx)).is_some() {}
+    fn clear_outputs(&self) {
         if let Some(publisher) = self
             .endpoint_publisher
             .lock()
@@ -517,109 +524,73 @@ impl<I: RefIO + 'static> StunClient<I> {
         }
         self.nat_type.clear();
         self.outer_addr.clear();
+    }
+
+    fn begin_close(&self) {
+        if self.closing.swap(true, SeqCst) {
+            return;
+        }
+        self.lock_tasks().abort_all();
+        self.clear_outputs();
+    }
+
+    pub fn poll_close(&self, cx: &mut Context) -> Poll<()> {
+        self.begin_close();
+        while ready!(self.lock_tasks().poll_join_next(cx)).is_some() {}
+        self.clear_outputs();
         Poll::Ready(())
     }
 }
 
-#[derive(Debug)]
-pub struct StunClientComponent {
-    client: Mutex<StunClient<WeakInterface>>,
-}
-
-impl StunClientComponent {
-    pub fn new(client: StunClient<WeakInterface>) -> Self {
-        Self {
-            client: Mutex::new(client),
-        }
-    }
-
-    fn lock_client(&self) -> MutexGuard<'_, StunClient<WeakInterface>> {
-        self.client.lock().expect("StunClient lock poisoned")
-    }
-
-    pub fn client(&self) -> StunClient<WeakInterface> {
-        self.lock_client().clone()
-    }
-}
-
-impl Component for StunClientComponent {
+impl Component for StunClient<WeakInterface> {
     fn poll_shutdown(&self, cx: &mut Context<'_>) -> Poll<()> {
-        self.lock_client().poll_close(cx)
+        self.poll_close(cx)
     }
 
     fn reinit(&self, iface: &Interface) {
-        let mut client = self.lock_client();
-        if client.ref_iface.same_io(&iface.downgrade()) {
-            return;
-        }
-
-        let Ok(Some((router, local_endpoints))) = iface.with_components(|components| {
-            let router = components.with(|router: &StunRouterComponent| {
-                router.reinit(iface);
-                router.router()
-            })?;
-            let local_endpoints = components.with(|local_endpoints: &LocalEndpointsComponent| {
-                local_endpoints.reinit(iface);
-                local_endpoints.clone()
-            });
-            Some((router, local_endpoints))
-        }) else {
-            return;
-        };
-
-        let new_client = StunClient::new(
-            iface.downgrade(),
-            router,
-            client.stun_agent,
-            local_endpoints,
-        );
-        *client = new_client;
+        debug_assert!(iface.bind_uri().is_temporary());
     }
 }
 
-type StunClientsMap<I> = HashMap<SocketAddr, StunClient<I>>;
-
-async fn resolve_stun_agents(
+async fn resolve_stun_agent(
     resolver: &(dyn Resolve + Send + Sync),
     server: &str,
     family: Family,
-) -> io::Result<Vec<SocketAddr>> {
+    excluded_agent: Option<SocketAddr>,
+) -> io::Result<Option<SocketAddr>> {
     let mut records = resolver.lookup(server).await?;
-    let mut agents = Vec::with_capacity(MAX_STUN_AGENTS);
 
     while let Some((_, endpoint)) = records.next().await {
         let EndpointAddr::Direct { addr } = endpoint else {
             continue;
         };
-        if addr.family() == family && !agents.contains(&addr) {
-            agents.push(addr);
-            if agents.len() == MAX_STUN_AGENTS {
-                break;
-            }
+        if addr.family() == family && Some(addr) != excluded_agent {
+            return Ok(Some(addr));
         }
     }
 
-    Ok(agents)
+    Ok(None)
 }
 
-async fn lookup_stun_agents(
+async fn lookup_stun_agent(
     resolver: &(dyn Resolve + Send + Sync),
     server: &str,
     family: Family,
-) -> Option<Vec<SocketAddr>> {
+    excluded_agent: Option<SocketAddr>,
+) -> Option<SocketAddr> {
     match tokio::time::timeout(
         STUN_AGENT_DNS_LOOKUP_TIMEOUT,
-        resolve_stun_agents(resolver, server, family),
+        resolve_stun_agent(resolver, server, family, excluded_agent),
     )
     .await
     {
-        Ok(Ok(discovered)) if !discovered.is_empty() => Some(discovered),
-        Ok(Ok(_)) => {
+        Ok(Ok(Some(agent))) => Some(agent),
+        Ok(Ok(None)) => {
             tracing::debug!(
                 target: "stun",
                 %server,
                 ?family,
-                "STUN agent lookup returned no compatible addresses"
+                "STUN agent lookup returned no compatible address"
             );
             None
         }
@@ -659,56 +630,59 @@ async fn wait_for_stun_interface<I: RefIO>(ref_iface: &I, family: Family) {
     }
 }
 
-async fn discover_stun_agents(
+async fn discover_stun_agent(
     resolver: &(dyn Resolve + Send + Sync),
     server: &str,
     family: Family,
-) -> Vec<SocketAddr> {
+) -> SocketAddr {
     let mut retry_interval = STUN_DISCOVERY_RETRY_INITIAL;
     loop {
-        if let Some(discovered) = lookup_stun_agents(resolver, server, family).await {
-            return discovered;
+        if let Some(agent) = lookup_stun_agent(resolver, server, family, None).await {
+            return agent;
         }
         tokio::time::sleep(retry_delay(&mut retry_interval, STUN_DISCOVERY_RETRY_MAX)).await;
     }
 }
 
-fn refresh_stun_clients<I, F>(
-    clients: &Mutex<StunClientsMap<I>>,
-    discovered: Vec<SocketAddr>,
+async fn replace_stun_client<I, F>(
+    client: &Mutex<Option<StunClient<I>>>,
+    active: &AtomicBool,
+    agent: SocketAddr,
     new_stun_client: F,
-) -> Vec<StunClient<I>>
+) -> bool
 where
     I: RefIO + 'static,
     F: Fn(SocketAddr) -> StunClient<I>,
 {
-    let mut clients = clients.lock().expect("StunClients mutex poisoned");
-    let mut refreshed = HashMap::with_capacity(discovered.len());
-    for agent in discovered {
-        let client = clients
-            .remove(&agent)
-            .unwrap_or_else(|| new_stun_client(agent));
-        refreshed.insert(agent, client);
+    let stale_client = {
+        let client = client.lock().expect("STUN client mutex poisoned");
+        if !active.load(SeqCst) {
+            return false;
+        }
+        if client
+            .as_ref()
+            .is_some_and(|client| client.agent_addr() == agent)
+        {
+            return false;
+        }
+        client.clone()
+    };
+    if let Some(stale_client) = stale_client {
+        core::future::poll_fn(|cx| stale_client.poll_close(cx)).await;
     }
-
-    let stale_clients = clients
-        .drain()
-        .map(|(_, client)| client)
-        .collect::<Vec<_>>();
-    *clients = refreshed;
-    stale_clients
-}
-
-async fn close_stun_clients<I: RefIO + 'static>(clients: Vec<StunClient<I>>) {
-    for client in clients {
-        core::future::poll_fn(|cx| client.poll_close(cx)).await;
+    let mut client = client.lock().expect("STUN client mutex poisoned");
+    if !active.load(SeqCst) {
+        return false;
     }
+    *client = Some(new_stun_client(agent));
+    true
 }
 
 #[derive(Debug)]
-struct StunClientsInner<I: RefIO + 'static> {
+struct StunClientState<I: RefIO + 'static> {
     ref_iface: I,
-    clients: Arc<Mutex<StunClientsMap<I>>>,
+    client: Arc<Mutex<Option<StunClient<I>>>>,
+    active: Arc<AtomicBool>,
     resolver: Arc<dyn Resolve + Send + Sync>,
     server: Arc<str>,
     task: Option<AbortOnDropHandle<()>>,
@@ -716,93 +690,129 @@ struct StunClientsInner<I: RefIO + 'static> {
 
 pub const DEFAULT_STUN_SERVER: &str = "nat.genmeta.net:20004";
 
-impl<I: RefIO + 'static> StunClientsInner<I> {
+impl<I: RefIO + 'static> StunClientState<I> {
     pub fn new(
         ref_iface: I,
         router: StunRouter,
         resolver: Arc<dyn Resolve + Send + Sync>,
         server: Arc<str>,
-        agents: impl IntoIterator<Item = SocketAddr>,
+        agent: Option<SocketAddr>,
         local_endpoints: Option<IfaceLocalEndpoints<I>>,
     ) -> Self {
         let family = ref_iface.iface().bind_uri().family();
         let interface_ready = stun_interface_ready(&ref_iface, family);
-        let new_stun_client = {
+        let known_agent = agent.filter(|agent| agent.family() == family);
+        let initial_client = known_agent.filter(|_| interface_ready).map(|agent| {
+            StunClient::new(
+                ref_iface.clone(),
+                router.clone(),
+                agent,
+                local_endpoints.clone(),
+            )
+        });
+        let client = Arc::new(Mutex::new(initial_client));
+        let active = Arc::new(AtomicBool::new(true));
+        let task = {
             let ref_iface = ref_iface.clone();
-            move |agent_addr: SocketAddr| {
-                let stun_router = router.clone();
-                StunClient::new(
-                    ref_iface.clone(),
-                    stun_router,
-                    agent_addr,
-                    local_endpoints.clone(),
-                )
-            }
-        };
-
-        let mut known_agents = Vec::with_capacity(MAX_STUN_AGENTS);
-        for agent in agents {
-            if known_agents.len() == MAX_STUN_AGENTS {
-                break;
-            }
-            if agent.family() == family && !known_agents.contains(&agent) {
-                known_agents.push(agent);
-            }
-        }
-        let mut initial_clients = HashMap::new();
-        if interface_ready {
-            for agent in &known_agents {
-                initial_clients.insert(*agent, new_stun_client(*agent));
-            }
-        }
-        let clients: Arc<Mutex<StunClientsMap<I>>> = Arc::new(Mutex::new(initial_clients));
-        let task = AbortOnDropHandle::new(tokio::spawn({
-            let clients = clients.clone();
-            let ref_iface = ref_iface.clone();
+            let client = client.clone();
+            let active = active.clone();
             let resolver = resolver.clone();
             let server = server.clone();
-            async move {
-                wait_for_stun_interface(&ref_iface, family).await;
+            AbortOnDropHandle::new(tokio::spawn(
+                async move {
+                    wait_for_stun_interface(&ref_iface, family).await;
 
-                if !interface_ready {
-                    let stale_clients =
-                        refresh_stun_clients(&clients, known_agents, &new_stun_client);
-                    close_stun_clients(stale_clients).await;
+                    let new_stun_client = |agent| {
+                        StunClient::new(
+                            ref_iface.clone(),
+                            router.clone(),
+                            agent,
+                            local_endpoints.clone(),
+                        )
+                    };
+
+                    if client.lock().expect("STUN client mutex poisoned").is_none() {
+                        let agent = match known_agent {
+                            Some(agent) => agent,
+                            None => {
+                                discover_stun_agent(resolver.as_ref(), server.as_ref(), family)
+                                    .await
+                            }
+                        };
+                        if replace_stun_client(&client, &active, agent, &new_stun_client).await {
+                            tracing::debug!(target: "stun", %agent, "installed STUN client");
+                        } else {
+                            return;
+                        }
+                    }
+
+                    loop {
+                        let active_client = client
+                            .lock()
+                            .expect("STUN client mutex poisoned")
+                            .clone()
+                            .expect("STUN client must be installed before monitoring");
+                        active_client.refresh_agent.notified().await;
+
+                        let previous_agent = active_client.agent_addr();
+                        let Some(agent) = lookup_stun_agent(
+                            resolver.as_ref(),
+                            server.as_ref(),
+                            family,
+                            Some(previous_agent),
+                        )
+                        .await
+                        else {
+                            continue;
+                        };
+                        if replace_stun_client(&client, &active, agent, &new_stun_client).await {
+                            tracing::debug!(
+                                target: "stun",
+                                %previous_agent,
+                                active_agent = %agent,
+                                "replaced failed STUN client after DNS refresh"
+                            );
+                        }
+                    }
                 }
-
-                let discovered =
-                    discover_stun_agents(resolver.as_ref(), server.as_ref(), family).await;
-                let stale_clients = refresh_stun_clients(&clients, discovered, new_stun_client);
-                close_stun_clients(stale_clients).await;
-                let count = clients.lock().expect("StunClients mutex poisoned").len();
-                tracing::debug!(target: "stun", count, "installed STUN clients");
-            }
-            .in_current_span()
-        }));
+                .in_current_span(),
+            ))
+        };
 
         Self {
             ref_iface,
-            clients,
+            client,
+            active,
             resolver,
             server,
             task: Some(task),
         }
     }
 
-    fn lock_clients(&self) -> MutexGuard<'_, StunClientsMap<I>> {
-        self.clients
-            .lock()
-            .expect("StunClientsComponentInner lock poisoned")
+    fn lock_client(&self) -> MutexGuard<'_, Option<StunClient<I>>> {
+        self.client.lock().expect("STUN client mutex poisoned")
+    }
+
+    fn begin_close(&mut self) {
+        self.active.store(false, SeqCst);
+        if let Some(task) = self.task.as_mut() {
+            task.abort();
+        }
+
+        let client = self.lock_client().clone();
+        if let Some(client) = client {
+            client.begin_close();
+        }
     }
 
     pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        self.begin_close();
         if let Some(task) = self.task.as_mut() {
-            task.abort();
             _ = ready!(task.poll_unpin(cx));
             self.task.take();
         }
 
-        for (.., client) in self.lock_clients().iter() {
+        if let Some(client) = self.lock_client().as_ref() {
             ready!(client.poll_close(cx))
         }
 
@@ -811,81 +821,77 @@ impl<I: RefIO + 'static> StunClientsInner<I> {
 }
 
 #[derive(Debug, Clone)]
-pub struct StunClients<I: RefIO + 'static> {
-    clients: Arc<Mutex<StunClientsInner<I>>>,
+pub struct StunClientComponent<I: RefIO + 'static = WeakInterface> {
+    state: Arc<Mutex<StunClientState<I>>>,
 }
 
-impl<I: RefIO + 'static> StunClients<I> {
+impl<I: RefIO + 'static> StunClientComponent<I> {
     pub fn new(
         ref_iface: I,
         router: StunRouter,
         resolver: Arc<dyn Resolve + Send + Sync>,
         server: impl Into<Arc<str>>,
-        agents: impl IntoIterator<Item = SocketAddr>,
+        agent: Option<SocketAddr>,
         local_endpoints: Option<IfaceLocalEndpoints<I>>,
     ) -> Self {
         Self {
-            clients: Arc::new(Mutex::new(StunClientsInner::new(
+            state: Arc::new(Mutex::new(StunClientState::new(
                 ref_iface,
                 router,
                 resolver,
                 server.into(),
-                agents,
+                agent,
                 local_endpoints,
             ))),
         }
     }
 
-    fn lock_clients(&self) -> MutexGuard<'_, StunClientsInner<I>> {
-        self.clients
-            .lock()
-            .expect("StunClientsComponent lock poisoned")
+    fn lock_state(&self) -> MutexGuard<'_, StunClientState<I>> {
+        self.state.lock().expect("STUN client state mutex poisoned")
     }
 
-    pub fn with_clients<T>(&self, f: impl FnOnce(&StunClientsMap<I>) -> T) -> T {
-        f(self.lock_clients().lock_clients().deref())
+    pub fn with_client<T>(&self, f: impl FnOnce(Option<&StunClient<I>>) -> T) -> T {
+        let state = self.lock_state();
+        f(state.lock_client().as_ref())
     }
 
     pub fn poll_close(&self, cx: &mut Context<'_>) -> Poll<()> {
-        self.lock_clients().poll_close(cx)
+        self.lock_state().poll_close(cx)
     }
 }
 
-pub type StunClientsComponent = StunClients<WeakInterface>;
-
-impl Component for StunClientsComponent {
+impl Component for StunClientComponent<WeakInterface> {
     fn poll_shutdown(&self, cx: &mut Context<'_>) -> Poll<()> {
-        self.lock_clients().poll_close(cx)
+        self.lock_state().poll_close(cx)
     }
 
     fn reinit(&self, iface: &Interface) {
-        let mut clients = self.lock_clients();
-        if clients.ref_iface.same_io(&iface.downgrade()) {
+        let mut state = self.lock_state();
+        if state.ref_iface.same_io(&iface.downgrade()) {
             return;
         }
 
         _ = iface.with_components(|components| {
-            let Some(router) = components.with(|router: &StunRouterComponent| {
-                router.reinit(iface);
-                router.router()
-            }) else {
+            let Some(router_component) = components.get::<StunRouterComponent>() else {
                 return;
             };
+            state.begin_close();
+            router_component.reinit(iface);
+            let router = router_component.router();
             let local_endpoints = components.with(|local_endpoints: &LocalEndpointsComponent| {
                 local_endpoints.reinit(iface);
                 local_endpoints.clone()
             });
 
-            let known_agents = clients.lock_clients().keys().copied().collect::<Vec<_>>();
-            let new_clients = StunClientsInner::new(
+            let new_state = StunClientState::new(
                 iface.downgrade(),
                 router,
-                clients.resolver.clone(),
-                clients.server.clone(),
-                known_agents,
+                state.resolver.clone(),
+                state.server.clone(),
+                None,
                 local_endpoints,
             );
-            *clients = new_clients;
+            *state = new_state;
         });
     }
 }

--- a/qtraversal/src/nat/client/tests.rs
+++ b/qtraversal/src/nat/client/tests.rs
@@ -1,9 +1,12 @@
 use std::{
     fmt,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc,
+    },
 };
 
-use futures::{FutureExt, StreamExt, stream};
+use futures::{FutureExt, StreamExt, stream, task::noop_waker_ref};
 use qresolve::{ResolveFuture, Source};
 
 use super::*;
@@ -63,40 +66,30 @@ fn direct(addr: &str) -> EndpointAddr {
 }
 
 #[tokio::test]
-async fn single_dns_result_is_a_complete_snapshot() {
+async fn single_dns_result_is_selected() {
     let resolver = TestResolver::new(LookupResult::Records(vec![direct("192.0.2.1:20004")]));
 
-    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4)
+    let agent = resolve_stun_agent(&resolver, "stun.example:20004", Family::V4, None)
         .await
         .unwrap();
 
-    assert_eq!(agents, vec!["192.0.2.1:20004".parse().unwrap()]);
+    assert_eq!(agent, Some("192.0.2.1:20004".parse().unwrap()));
     assert_eq!(resolver.lookup_count(), 1);
 }
 
 #[tokio::test]
-async fn dns_snapshot_is_filtered_deduplicated_and_bounded() {
+async fn dns_lookup_selects_first_compatible_agent() {
     let resolver = TestResolver::new(LookupResult::Records(vec![
-        direct("192.0.2.1:20004"),
-        direct("192.0.2.1:20004"),
         direct("[2001:db8::1]:20004"),
+        direct("192.0.2.1:20004"),
         direct("192.0.2.2:20004"),
-        direct("192.0.2.3:20004"),
-        direct("192.0.2.4:20004"),
     ]));
 
-    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4)
+    let agent = resolve_stun_agent(&resolver, "stun.example:20004", Family::V4, None)
         .await
         .unwrap();
 
-    assert_eq!(
-        agents,
-        vec![
-            "192.0.2.1:20004".parse().unwrap(),
-            "192.0.2.2:20004".parse().unwrap(),
-            "192.0.2.3:20004".parse().unwrap(),
-        ]
-    );
+    assert_eq!(agent, Some("192.0.2.1:20004".parse().unwrap()));
     assert_eq!(resolver.lookup_count(), 1);
 }
 
@@ -104,9 +97,52 @@ async fn dns_snapshot_is_filtered_deduplicated_and_bounded() {
 async fn dns_failure_is_reported_to_discovery_loop() {
     let resolver = TestResolver::new(LookupResult::Error);
 
-    let result = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+    let result = resolve_stun_agent(&resolver, "stun.example:20004", Family::V4, None).await;
 
     assert!(result.is_err());
+    assert_eq!(resolver.lookup_count(), 1);
+}
+
+#[tokio::test]
+async fn dns_lookup_skips_the_failed_active_agent() {
+    let failed_agent = "192.0.2.1:20004".parse().unwrap();
+    let replacement_agent = "192.0.2.2:20004".parse().unwrap();
+    let resolver = TestResolver::new(LookupResult::Records(vec![
+        EndpointAddr::direct(failed_agent),
+        EndpointAddr::direct(replacement_agent),
+    ]));
+
+    let agent = resolve_stun_agent(
+        &resolver,
+        "stun.example:20004",
+        Family::V4,
+        Some(failed_agent),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(agent, Some(replacement_agent));
+    assert_eq!(resolver.lookup_count(), 1);
+}
+
+#[tokio::test]
+async fn dns_lookup_returns_none_when_only_the_failed_agent_remains() {
+    let failed_agent = "192.0.2.1:20004".parse().unwrap();
+    let resolver = TestResolver::new(LookupResult::Records(vec![
+        EndpointAddr::direct(failed_agent),
+        EndpointAddr::direct(failed_agent),
+    ]));
+
+    let agent = resolve_stun_agent(
+        &resolver,
+        "stun.example:20004",
+        Family::V4,
+        Some(failed_agent),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(agent, None);
     assert_eq!(resolver.lookup_count(), 1);
 }
 
@@ -118,52 +154,187 @@ async fn stun_discovery_is_dormant_when_local_address_is_unavailable() {
     let iface = Arc::new(Unsupported::bind("inet://0.0.0.0:0".into()));
     assert!(iface.bound_addr().is_err());
     let resolver = TestResolver::new(LookupResult::Error);
-    let clients = StunClients::new(
+    let component = StunClientComponent::new(
         iface,
         StunRouter::new(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::once(agent),
+        Some(agent),
         None,
     );
 
-    assert!(clients.with_clients(|clients| clients.is_empty()));
+    assert!(component.with_client(|client| client.is_none()));
     tokio::task::yield_now().await;
     assert_eq!(resolver.lookup_count(), 0);
 }
 
 #[tokio::test]
-async fn existing_clients_are_refreshed_from_dns() {
+async fn known_agent_is_installed_immediately() {
+    use qinterface::io::{ProductIO, handy::DEFAULT_IO_FACTORY};
+
+    let first_agent = "192.0.2.1:20004".parse().unwrap();
+    let iface: Arc<dyn IO> = Arc::from(DEFAULT_IO_FACTORY.bind("inet://127.0.0.1:0".into()));
+    let component = StunClientComponent::new(
+        iface,
+        StunRouter::new(),
+        Arc::new(TestResolver::new(LookupResult::Error)),
+        "stun.example:20004",
+        Some(first_agent),
+        None,
+    );
+
+    assert!(
+        component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == first_agent)
+        })
+    );
+}
+
+#[tokio::test]
+async fn failed_client_is_replaced_from_a_fresh_dns_lookup() {
     use qinterface::io::{ProductIO, handy::DEFAULT_IO_FACTORY};
 
     let old_agent = "192.0.2.1:20004".parse().unwrap();
     let new_agent = "192.0.2.2:20004".parse().unwrap();
     let iface: Arc<dyn IO> = Arc::from(DEFAULT_IO_FACTORY.bind("inet://127.0.0.1:0".into()));
     assert!(iface.bound_addr().is_ok());
-    let resolver = TestResolver::new(LookupResult::Records(vec![EndpointAddr::direct(new_agent)]));
-    let clients = StunClients::new(
+    let resolver = TestResolver::new(LookupResult::Records(vec![
+        EndpointAddr::direct(old_agent),
+        EndpointAddr::direct(new_agent),
+    ]));
+    let component = StunClientComponent::new(
         iface,
         StunRouter::new(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::once(old_agent),
+        Some(old_agent),
         None,
     );
 
-    assert!(clients.with_clients(|clients| clients.contains_key(&old_agent)));
+    assert!(
+        component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == old_agent)
+        })
+    );
+    component.with_client(|client| {
+        client
+            .expect("old STUN client missing")
+            .refresh_agent
+            .notify_one();
+    });
     tokio::time::timeout(Duration::from_secs(3), async {
-        while !clients.with_clients(|clients| clients.contains_key(&new_agent)) {
+        while !component
+            .with_client(|client| client.is_some_and(|client| client.agent_addr() == new_agent))
+        {
             tokio::task::yield_now().await;
         }
     })
     .await
     .expect("refreshed STUN agent was not installed");
 
-    assert_eq!(resolver.lookup_count(), 1);
-    clients.with_clients(|clients| {
-        assert_eq!(clients.len(), 1);
-        assert!(!clients.contains_key(&old_agent));
+    assert!(resolver.lookup_count() >= 1);
+    assert!(
+        component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == new_agent)
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn poll_close_stays_pending_until_all_tasks_exit() {
+    use qinterface::io::{ProductIO, handy::DEFAULT_IO_FACTORY};
+
+    let iface: Arc<dyn IO> = Arc::from(DEFAULT_IO_FACTORY.bind("inet://127.0.0.1:0".into()));
+    let client = StunClient::new(
+        iface,
+        StunRouter::new(),
+        "192.0.2.1:20004".parse().unwrap(),
+        None,
+    );
+
+    let (task_started_tx, task_started_rx) = mpsc::channel();
+    let (release_task_tx, release_task_rx) = mpsc::channel();
+    client.lock_tasks().spawn(async move {
+        task_started_tx.send(()).unwrap();
+        let _ = release_task_rx.recv();
     });
+    task_started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("blocking STUN task did not start");
+
+    let mut cx = Context::from_waker(noop_waker_ref());
+    assert!(client.poll_close(&mut cx).is_pending());
+    assert!(client.poll_close(&mut cx).is_pending());
+
+    release_task_tx.send(()).unwrap();
+    tokio::time::timeout(
+        Duration::from_secs(3),
+        core::future::poll_fn(|cx| client.poll_close(cx)),
+    )
+    .await
+    .expect("STUN client did not finish closing");
+    assert!(client.lock_tasks().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inactive_generation_cannot_finish_an_inflight_replacement() {
+    use qinterface::io::{ProductIO, handy::DEFAULT_IO_FACTORY};
+
+    let old_agent = "192.0.2.1:20004".parse().unwrap();
+    let new_agent = "192.0.2.2:20004".parse().unwrap();
+    let iface: Arc<dyn IO> = Arc::from(DEFAULT_IO_FACTORY.bind("inet://127.0.0.1:0".into()));
+    let old_client = StunClient::new(iface, StunRouter::new(), old_agent, None);
+
+    let (task_started_tx, task_started_rx) = mpsc::channel();
+    let (release_task_tx, release_task_rx) = mpsc::channel();
+    old_client.lock_tasks().spawn(async move {
+        task_started_tx.send(()).unwrap();
+        let _ = release_task_rx.recv();
+    });
+    task_started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("blocking STUN task did not start");
+
+    let client = Arc::new(Mutex::new(Some(old_client)));
+    let active = Arc::new(AtomicBool::new(true));
+    let replacement = tokio::spawn({
+        let client = client.clone();
+        let active = active.clone();
+        async move {
+            replace_stun_client(&client, &active, new_agent, |_| {
+                panic!("inactive generation installed a replacement client")
+            })
+            .await
+        }
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !client
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .closing
+            .load(Ordering::SeqCst)
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replacement did not begin closing the old client");
+
+    active.store(false, Ordering::SeqCst);
+    release_task_tx.send(()).unwrap();
+    let replaced = tokio::time::timeout(Duration::from_secs(3), replacement)
+        .await
+        .expect("replacement did not finish")
+        .expect("replacement task panicked");
+
+    assert!(!replaced);
+    assert_eq!(
+        client.lock().unwrap().as_ref().unwrap().agent_addr(),
+        old_agent
+    );
 }
 
 #[test]

--- a/qtraversal/src/nat/client/tests.rs
+++ b/qtraversal/src/nat/client/tests.rs
@@ -66,7 +66,9 @@ fn direct(addr: &str) -> EndpointAddr {
 async fn single_dns_result_is_a_complete_snapshot() {
     let resolver = TestResolver::new(LookupResult::Records(vec![direct("192.0.2.1:20004")]));
 
-    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4)
+        .await
+        .unwrap();
 
     assert_eq!(agents, vec!["192.0.2.1:20004".parse().unwrap()]);
     assert_eq!(resolver.lookup_count(), 1);
@@ -83,7 +85,9 @@ async fn dns_snapshot_is_filtered_deduplicated_and_bounded() {
         direct("192.0.2.4:20004"),
     ]));
 
-    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4)
+        .await
+        .unwrap();
 
     assert_eq!(
         agents,
@@ -97,11 +101,138 @@ async fn dns_snapshot_is_filtered_deduplicated_and_bounded() {
 }
 
 #[tokio::test]
-async fn dns_failure_is_not_retried() {
+async fn dns_failure_is_reported_to_discovery_loop() {
     let resolver = TestResolver::new(LookupResult::Error);
 
-    let agents = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
+    let result = resolve_stun_agents(&resolver, "stun.example:20004", Family::V4).await;
 
-    assert!(agents.is_empty());
+    assert!(result.is_err());
     assert_eq!(resolver.lookup_count(), 1);
+}
+
+#[tokio::test]
+async fn stun_discovery_is_dormant_when_local_address_is_unavailable() {
+    use qinterface::io::handy::unsupported::Unsupported;
+
+    let agent = "192.0.2.1:20004".parse().unwrap();
+    let iface = Arc::new(Unsupported::bind("inet://0.0.0.0:0".into()));
+    assert!(iface.bound_addr().is_err());
+    let resolver = TestResolver::new(LookupResult::Error);
+    let clients = StunClients::new(
+        iface,
+        StunRouter::new(),
+        Arc::new(resolver.clone()),
+        "stun.example:20004",
+        std::iter::once(agent),
+        None,
+    );
+
+    assert!(clients.with_clients(|clients| clients.is_empty()));
+    tokio::task::yield_now().await;
+    assert_eq!(resolver.lookup_count(), 0);
+}
+
+#[tokio::test]
+async fn existing_clients_are_refreshed_from_dns() {
+    use qinterface::io::{ProductIO, handy::DEFAULT_IO_FACTORY};
+
+    let old_agent = "192.0.2.1:20004".parse().unwrap();
+    let new_agent = "192.0.2.2:20004".parse().unwrap();
+    let iface: Arc<dyn IO> = Arc::from(DEFAULT_IO_FACTORY.bind("inet://127.0.0.1:0".into()));
+    assert!(iface.bound_addr().is_ok());
+    let resolver = TestResolver::new(LookupResult::Records(vec![EndpointAddr::direct(new_agent)]));
+    let clients = StunClients::new(
+        iface,
+        StunRouter::new(),
+        Arc::new(resolver.clone()),
+        "stun.example:20004",
+        std::iter::once(old_agent),
+        None,
+    );
+
+    assert!(clients.with_clients(|clients| clients.contains_key(&old_agent)));
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while !clients.with_clients(|clients| clients.contains_key(&new_agent)) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("refreshed STUN agent was not installed");
+
+    assert_eq!(resolver.lookup_count(), 1);
+    clients.with_clients(|clients| {
+        assert_eq!(clients.len(), 1);
+        assert!(!clients.contains_key(&old_agent));
+    });
+}
+
+#[test]
+fn stun_probe_failure_backoff_is_bounded() {
+    let mut retry_interval = STUN_PROBE_RETRY_INITIAL;
+
+    let delays = (0..11)
+        .map(|_| stun_probe_delay(false, &mut retry_interval))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        delays,
+        [1, 2, 4, 8, 16, 32, 64, 128, 256, 300, 300].map(Duration::from_secs)
+    );
+    assert_eq!(retry_interval, STUN_PROBE_RETRY_MAX);
+}
+
+#[test]
+fn stun_probe_success_resets_backoff() {
+    let mut retry_interval = STUN_PROBE_RETRY_INITIAL;
+    assert_eq!(
+        stun_probe_delay(false, &mut retry_interval),
+        Duration::from_secs(1)
+    );
+    assert_eq!(
+        stun_probe_delay(false, &mut retry_interval),
+        Duration::from_secs(2)
+    );
+
+    assert_eq!(
+        stun_probe_delay(true, &mut retry_interval),
+        NAT_MAPPING_REFRESH_INTERVAL
+    );
+    assert_eq!(retry_interval, STUN_PROBE_RETRY_INITIAL);
+    assert_eq!(
+        stun_probe_delay(false, &mut retry_interval),
+        Duration::from_secs(1)
+    );
+}
+
+#[test]
+fn recent_stun_endpoint_is_retained_during_failure_grace_period() {
+    let last_success = Instant::now();
+
+    assert!(retain_last_stun_endpoint(
+        Some(last_success),
+        last_success + STUN_ENDPOINT_FAILURE_GRACE_PERIOD - Duration::from_millis(1),
+    ));
+    assert!(!retain_last_stun_endpoint(
+        Some(last_success),
+        last_success + STUN_ENDPOINT_FAILURE_GRACE_PERIOD,
+    ));
+    assert!(!retain_last_stun_endpoint(
+        None,
+        last_success + Duration::from_secs(1),
+    ));
+}
+
+#[test]
+fn discovery_retry_backoff_is_bounded() {
+    let mut retry_interval = STUN_DISCOVERY_RETRY_INITIAL;
+
+    let delays = (0..11)
+        .map(|_| retry_delay(&mut retry_interval, STUN_DISCOVERY_RETRY_MAX))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        delays,
+        [1, 2, 4, 8, 16, 32, 64, 128, 256, 300, 300].map(Duration::from_secs)
+    );
+    assert_eq!(retry_interval, STUN_DISCOVERY_RETRY_MAX);
 }

--- a/qtraversal/src/punch/puncher.rs
+++ b/qtraversal/src/punch/puncher.rs
@@ -43,10 +43,7 @@ use tracing::Instrument as _;
 
 use crate::{
     addr::AddressBook,
-    nat::{
-        client::{StunClientComponent, StunClientsComponent},
-        router::StunRouterComponent,
-    },
+    nat::{client::StunClientComponent, router::StunRouterComponent},
     punch::{
         predictor::{PacketSendFn, PortPredictor},
         tx::{AsPunchId, PunchId, Transaction},
@@ -721,10 +718,14 @@ where
             return;
         };
 
-        let client = iface.with_component(|clients: &StunClientsComponent| {
-            clients.with_clients(|map| map.get(&agent).cloned())
+        let client = iface.with_component(|component: &StunClientComponent| {
+            component.with_client(|client| {
+                client
+                    .filter(|client| client.agent_addr() == agent)
+                    .cloned()
+            })
         });
-        let Some(Some(Some(client))) = client.ok() else {
+        let Some(client) = client.ok().flatten().flatten() else {
             tracing::debug!(target: "punch", %bind_uri, %agent, "cannot advertise agent endpoint without matching STUN client");
             return;
         };
@@ -1869,11 +1870,9 @@ async fn dynamic_iface(
                 .router();
             let stun_client = components
                 .init_with(|| {
-                    let client =
-                        StunClient::new(iface.downgrade(), stun_router.clone(), stun_server, None);
-                    StunClientComponent::new(client)
+                    StunClient::new(iface.downgrade(), stun_router.clone(), stun_server, None)
                 })
-                .client();
+                .clone();
             components.init_with(|| {
                 ReceiveAndDeliverPacket::builder(iface.downgrade())
                     .quic_router(quic_router.clone())

--- a/qtraversal/src/route.rs
+++ b/qtraversal/src/route.rs
@@ -26,7 +26,6 @@ use qinterface::{
     },
     io::{IO, IoExt, RefIO},
 };
-use smallvec::SmallVec;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Instrument as _;
 
@@ -34,7 +33,7 @@ pub type ArcRecvQueue = ArcAsyncDeque<(BytesMut, Pathway, Link)>;
 
 use crate::{
     nat::{
-        client::{StunClients, StunClientsComponent},
+        client::StunClientComponent,
         router::{StunRouter, StunRouterComponent},
     },
     packet::{ForwardHeader, StunHeader},
@@ -42,29 +41,21 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub enum Forwarder<I: RefIO + 'static> {
-    Clients { stun_clients: StunClients<I> },
+    Client { stun_client: StunClientComponent<I> },
     Server { outer_addr: SocketAddr },
 }
 
 impl<I: RefIO> Forwarder<I> {
-    pub fn outers(&self) -> SmallVec<[SocketAddr; 8]> {
+    pub fn outer(&self) -> Option<SocketAddr> {
         match self {
-            Forwarder::Clients { stun_clients } => stun_clients.with_clients(|clients| {
-                clients
-                    .values()
-                    .filter_map(|client| client.get_outer_addr()?.ok())
-                    .collect()
-            }),
-            Forwarder::Server { outer_addr } => SmallVec::from_iter([*outer_addr]),
+            Forwarder::Client { stun_client } => stun_client
+                .with_client(|client| client.and_then(|client| client.get_outer_addr()?.ok())),
+            Forwarder::Server { outer_addr } => Some(*outer_addr),
         }
     }
 
     pub fn should_forward(&self, dst: EndpointAddr) -> Option<SocketAddr> {
-        let outers = self.outers();
-
-        if outers.is_empty() {
-            return None;
-        }
+        let outer = self.outer()?;
 
         let EndpointAddr::Agent {
             agent,
@@ -74,17 +65,11 @@ impl<I: RefIO> Forwarder<I> {
             return None;
         };
 
-        for outer in outers {
-            if outer == dst_outer {
-                return None;
-            }
-
-            if outer == agent {
-                return Some(dst_outer);
-            }
+        if outer == dst_outer {
+            return None;
         }
 
-        Some(agent)
+        Some(if outer == agent { dst_outer } else { agent })
     }
 }
 
@@ -100,8 +85,8 @@ impl ForwardersComponent {
         }
     }
 
-    pub fn new_client(stun_clients: StunClients<WeakInterface>) -> Self {
-        Self::new(Forwarder::Clients { stun_clients })
+    pub fn new_client(stun_client: StunClientComponent<WeakInterface>) -> Self {
+        Self::new(Forwarder::Client { stun_client })
     }
 
     pub fn new_server(outer_addr: SocketAddr) -> Self {
@@ -123,10 +108,10 @@ impl Component for ForwardersComponent {
     }
 
     fn reinit(&self, iface: &Interface) {
-        _ = iface.with_component(|clients: &StunClientsComponent| {
-            clients.reinit(iface);
-            *self.lock_forwarders() = Forwarder::Clients {
-                stun_clients: clients.clone(),
+        _ = iface.with_component(|component: &StunClientComponent| {
+            component.reinit(iface);
+            *self.lock_forwarders() = Forwarder::Client {
+                stun_client: component.clone(),
             };
         });
     }

--- a/qtraversal/tests/reinit.rs
+++ b/qtraversal/tests/reinit.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt, io,
+    net::SocketAddr,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -7,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{FutureExt, StreamExt, stream};
+use futures::{FutureExt, StreamExt, future, stream};
 use qbase::net::addr::EndpointAddr;
 use qinterface::{
     bind_uri::BindUri, component::Component, io::handy::DEFAULT_IO_FACTORY,
@@ -30,6 +31,84 @@ impl CountingResolver {
     }
 }
 
+#[derive(Debug, Clone)]
+struct RecoveringResolver {
+    lookups: Arc<AtomicUsize>,
+    agent: SocketAddr,
+}
+
+#[derive(Debug, Clone)]
+struct TimeoutThenRecoveringResolver {
+    lookups: Arc<AtomicUsize>,
+    agent: SocketAddr,
+}
+
+impl TimeoutThenRecoveringResolver {
+    fn new(agent: SocketAddr) -> Self {
+        Self {
+            lookups: Arc::new(AtomicUsize::new(0)),
+            agent,
+        }
+    }
+
+    fn lookup_count(&self) -> usize {
+        self.lookups.load(Ordering::SeqCst)
+    }
+}
+
+impl RecoveringResolver {
+    fn new(agent: SocketAddr) -> Self {
+        Self {
+            lookups: Arc::new(AtomicUsize::new(0)),
+            agent,
+        }
+    }
+
+    fn lookup_count(&self) -> usize {
+        self.lookups.load(Ordering::SeqCst)
+    }
+}
+
+impl fmt::Display for RecoveringResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("recovering resolver")
+    }
+}
+
+impl Resolve for RecoveringResolver {
+    fn lookup<'l>(&'l self, _name: &'l str) -> ResolveFuture<'l> {
+        let lookup = self.lookups.fetch_add(1, Ordering::SeqCst);
+        let agent = self.agent;
+        async move {
+            if lookup == 0 {
+                return Err(io::Error::other("network is not ready"));
+            }
+            Ok(stream::once(async move { (Source::System, EndpointAddr::direct(agent)) }).boxed())
+        }
+        .boxed()
+    }
+}
+
+impl fmt::Display for TimeoutThenRecoveringResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("timeout then recovering resolver")
+    }
+}
+
+impl Resolve for TimeoutThenRecoveringResolver {
+    fn lookup<'l>(&'l self, _name: &'l str) -> ResolveFuture<'l> {
+        let lookup = self.lookups.fetch_add(1, Ordering::SeqCst);
+        let agent = self.agent;
+        async move {
+            if lookup == 0 {
+                future::pending::<()>().await;
+            }
+            Ok(stream::once(async move { (Source::System, EndpointAddr::direct(agent)) }).boxed())
+        }
+        .boxed()
+    }
+}
+
 impl fmt::Display for CountingResolver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("counting resolver")
@@ -47,9 +126,35 @@ impl Resolve for CountingResolver {
     }
 }
 
-async fn wait_for_lookup_count(resolver: &CountingResolver, expected: usize) -> io::Result<()> {
-    tokio::time::timeout(Duration::from_secs(1), async {
+async fn wait_for_counting_lookup_count(
+    resolver: &CountingResolver,
+    expected: usize,
+) -> io::Result<()> {
+    tokio::time::timeout(Duration::from_secs(3), async {
         while resolver.lookup_count() < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(io::Error::other)
+}
+
+async fn wait_for_recovering_lookup_count(
+    resolver: &RecoveringResolver,
+    expected: usize,
+) -> io::Result<()> {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while resolver.lookup_count() < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(io::Error::other)
+}
+
+async fn wait_for_client_count(clients: &StunClientsComponent, expected: usize) -> io::Result<()> {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while clients.with_clients(|clients| clients.len()) < expected {
             tokio::task::yield_now().await;
         }
     })
@@ -102,7 +207,7 @@ async fn receive_reinit_refreshes_stun_router_dependency() {
 }
 
 #[tokio::test]
-async fn stun_clients_lookup_once_for_each_interface_generation() {
+async fn stun_clients_preserve_known_agents_across_reinit() {
     let manager = InterfaceManager::global().clone();
     let old_bind = manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
@@ -110,15 +215,17 @@ async fn stun_clients_lookup_once_for_each_interface_generation() {
     let old_iface = old_bind.borrow();
     let stun = StunRouterComponent::new(old_iface.downgrade());
     let resolver = CountingResolver::default();
+    let known_agent: SocketAddr = "192.0.2.1:20004".parse().unwrap();
     let clients = StunClientsComponent::new(
         old_iface.downgrade(),
         stun.router(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::empty(),
+        std::iter::once(known_agent),
         None,
     );
-    wait_for_lookup_count(&resolver, 1).await.unwrap();
+    assert!(clients.with_clients(|clients| clients.contains_key(&known_agent)));
+    wait_for_counting_lookup_count(&resolver, 1).await.unwrap();
 
     let new_bind = manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
@@ -130,8 +237,72 @@ async fn stun_clients_lookup_once_for_each_interface_generation() {
         components.with(|clients: &StunClientsComponent| clients.reinit(iface))
     });
     assert!(reinit_called.is_some());
-    wait_for_lookup_count(&resolver, 2).await.unwrap();
+    wait_for_counting_lookup_count(&resolver, 2).await.unwrap();
+
+    assert!(clients.with_clients(|clients| clients.contains_key(&known_agent)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn stun_clients_retry_lookup_after_transient_failure() {
+    let manager = InterfaceManager::global().clone();
+    let bind = manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    let iface = bind.borrow();
+    let stun = StunRouterComponent::new(iface.downgrade());
+    let agent: SocketAddr = "192.0.2.2:20004".parse().unwrap();
+    let resolver = RecoveringResolver::new(agent);
+    let clients = StunClientsComponent::new(
+        iface.downgrade(),
+        stun.router(),
+        Arc::new(resolver.clone()),
+        "stun.example:20004",
+        std::iter::empty(),
+        None,
+    );
+
+    wait_for_recovering_lookup_count(&resolver, 1)
+        .await
+        .unwrap();
+    assert_eq!(clients.with_clients(|clients| clients.len()), 0);
+
     tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(10)).await;
+    wait_for_recovering_lookup_count(&resolver, 2)
+        .await
+        .unwrap();
+    wait_for_client_count(&clients, 1).await.unwrap();
+
+    assert!(clients.with_clients(|clients| clients.contains_key(&agent)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn stun_clients_retry_lookup_after_timeout() {
+    let manager = InterfaceManager::global().clone();
+    let bind = manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    let iface = bind.borrow();
+    let stun = StunRouterComponent::new(iface.downgrade());
+    let agent: SocketAddr = "192.0.2.3:20004".parse().unwrap();
+    let resolver = TimeoutThenRecoveringResolver::new(agent);
+    let clients = StunClientsComponent::new(
+        iface.downgrade(),
+        stun.router(),
+        Arc::new(resolver.clone()),
+        "stun.example:20004",
+        std::iter::empty(),
+        None,
+    );
+
+    tokio::task::yield_now().await;
+    assert_eq!(resolver.lookup_count(), 1);
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(10)).await;
+    wait_for_client_count(&clients, 1).await.unwrap();
 
     assert_eq!(resolver.lookup_count(), 2);
+    assert!(clients.with_clients(|clients| clients.contains_key(&agent)));
 }

--- a/qtraversal/tests/reinit.rs
+++ b/qtraversal/tests/reinit.rs
@@ -4,7 +4,9 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
+        mpsc,
     },
+    thread,
     time::Duration,
 };
 
@@ -16,20 +18,12 @@ use qinterface::{
 };
 use qresolve::{Resolve, ResolveFuture, Source};
 use qtraversal::{
-    nat::{client::StunClientsComponent, router::StunRouterComponent},
+    nat::{
+        client::{DetectNatTypeError, DetectOuterAddrError, StunClientComponent},
+        router::StunRouterComponent,
+    },
     route::ReceiveAndDeliverPacketComponent,
 };
-
-#[derive(Debug, Clone, Default)]
-struct CountingResolver {
-    lookups: Arc<AtomicUsize>,
-}
-
-impl CountingResolver {
-    fn lookup_count(&self) -> usize {
-        self.lookups.load(Ordering::SeqCst)
-    }
-}
 
 #[derive(Debug, Clone)]
 struct RecoveringResolver {
@@ -109,36 +103,6 @@ impl Resolve for TimeoutThenRecoveringResolver {
     }
 }
 
-impl fmt::Display for CountingResolver {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("counting resolver")
-    }
-}
-
-impl Resolve for CountingResolver {
-    fn lookup<'l>(&'l self, _name: &'l str) -> ResolveFuture<'l> {
-        self.lookups.fetch_add(1, Ordering::SeqCst);
-        async move {
-            let records = stream::empty::<(Source, EndpointAddr)>().boxed();
-            Ok(records)
-        }
-        .boxed()
-    }
-}
-
-async fn wait_for_counting_lookup_count(
-    resolver: &CountingResolver,
-    expected: usize,
-) -> io::Result<()> {
-    tokio::time::timeout(Duration::from_secs(3), async {
-        while resolver.lookup_count() < expected {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .map_err(io::Error::other)
-}
-
 async fn wait_for_recovering_lookup_count(
     resolver: &RecoveringResolver,
     expected: usize,
@@ -152,9 +116,9 @@ async fn wait_for_recovering_lookup_count(
     .map_err(io::Error::other)
 }
 
-async fn wait_for_client_count(clients: &StunClientsComponent, expected: usize) -> io::Result<()> {
+async fn wait_for_client(component: &StunClientComponent) -> io::Result<()> {
     tokio::time::timeout(Duration::from_secs(3), async {
-        while clients.with_clients(|clients| clients.len()) < expected {
+        while component.with_client(|client| client.is_none()) {
             tokio::task::yield_now().await;
         }
     })
@@ -207,91 +171,237 @@ async fn receive_reinit_refreshes_stun_router_dependency() {
 }
 
 #[tokio::test]
-async fn stun_clients_preserve_known_agents_across_reinit() {
-    let manager = InterfaceManager::global().clone();
-    let old_bind = manager
+async fn stun_client_refreshes_dns_across_reinit() {
+    let interface_manager = InterfaceManager::global().clone();
+    let old_bind = interface_manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
         .await;
     let old_iface = old_bind.borrow();
     let stun = StunRouterComponent::new(old_iface.downgrade());
-    let resolver = CountingResolver::default();
     let known_agent: SocketAddr = "192.0.2.1:20004".parse().unwrap();
-    let clients = StunClientsComponent::new(
+    let resolver = RecoveringResolver::new(known_agent);
+    let stun_component = StunClientComponent::new(
         old_iface.downgrade(),
         stun.router(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::once(known_agent),
+        Some(known_agent),
         None,
     );
-    assert!(clients.with_clients(|clients| clients.contains_key(&known_agent)));
-    wait_for_counting_lookup_count(&resolver, 1).await.unwrap();
-
-    let new_bind = manager
+    assert!(
+        stun_component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == known_agent)
+        })
+    );
+    let new_bind = interface_manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
         .await;
     new_bind.insert_component_with(|_| stun);
-    new_bind.insert_component_with(|_| clients.clone());
+    new_bind.insert_component_with(|_| stun_component.clone());
 
     let reinit_called = new_bind.with_components(|components, iface| {
-        components.with(|clients: &StunClientsComponent| clients.reinit(iface))
+        components.with(|component: &StunClientComponent| component.reinit(iface))
     });
     assert!(reinit_called.is_some());
-    wait_for_counting_lookup_count(&resolver, 2).await.unwrap();
+    wait_for_recovering_lookup_count(&resolver, 1)
+        .await
+        .unwrap();
+    wait_for_client(&stun_component).await.unwrap();
+    assert!(resolver.lookup_count() >= 2);
+    assert!(
+        stun_component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == known_agent)
+        })
+    );
+}
 
-    assert!(clients.with_clients(|clients| clients.contains_key(&known_agent)));
+#[tokio::test]
+async fn reinit_invalidates_escaped_client_clone() {
+    let interface_manager = InterfaceManager::global().clone();
+    let old_bind = interface_manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    let old_iface = old_bind.borrow();
+    let stun = StunRouterComponent::new(old_iface.downgrade());
+    let known_agent: SocketAddr = "192.0.2.1:20004".parse().unwrap();
+    let stun_component = StunClientComponent::new(
+        old_iface.downgrade(),
+        stun.router(),
+        Arc::new(RecoveringResolver::new(known_agent)),
+        "stun.example:20004",
+        Some(known_agent),
+        None,
+    );
+    let stale_client = stun_component
+        .with_client(|client| client.cloned())
+        .expect("known STUN client missing");
+
+    assert!(!matches!(
+        stale_client.get_outer_addr(),
+        Some(Err(DetectOuterAddrError::Rebinded { .. }))
+    ));
+    assert!(!matches!(
+        stale_client.get_nat_type(),
+        Some(Err(DetectNatTypeError::Rebinded { .. }))
+    ));
+
+    let new_bind = interface_manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    new_bind.insert_component_with(|_| stun);
+    new_bind.insert_component_with(|_| stun_component.clone());
+    new_bind.with_components(|components, iface| {
+        components
+            .with(|component: &StunClientComponent| component.reinit(iface))
+            .expect("STUN client component missing");
+    });
+
+    assert!(matches!(
+        stale_client.get_outer_addr(),
+        Some(Err(DetectOuterAddrError::Rebinded { .. }))
+    ));
+    assert!(matches!(
+        stale_client.get_nat_type(),
+        Some(Err(DetectNatTypeError::Rebinded { .. }))
+    ));
+    wait_for_client(&stun_component).await.unwrap();
+    assert!(
+        stun_component.with_client(|client| {
+            client.is_some_and(|client| client.agent_addr() == known_agent)
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn with_client_blocks_reinit_until_reader_finishes() {
+    #[derive(Debug, PartialEq)]
+    enum Step {
+        ReaderHasLock,
+        ReinitStarted,
+        ReinitFinished,
+    }
+
+    let interface_manager = InterfaceManager::global().clone();
+    let old_bind = interface_manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    let old_iface = old_bind.borrow();
+    let stun = StunRouterComponent::new(old_iface.downgrade());
+    let known_agent: SocketAddr = "192.0.2.1:20004".parse().unwrap();
+    let stun_component = StunClientComponent::new(
+        old_iface.downgrade(),
+        stun.router(),
+        Arc::new(RecoveringResolver::new(known_agent)),
+        "stun.example:20004",
+        Some(known_agent),
+        None,
+    );
+
+    let new_bind = interface_manager
+        .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
+        .await;
+    new_bind.insert_component_with(|_| stun);
+    new_bind.insert_component_with(|_| stun_component.clone());
+
+    // Reader: |------- with_client holds the state lock -------|
+    // Reinit:          |---------- blocked ----------| reinit
+    let (step_tx, step_rx) = mpsc::channel();
+    let (release_reader_tx, release_reader_rx) = mpsc::channel();
+    let reader_component = stun_component.clone();
+    let reader_step_tx = step_tx.clone();
+    let reader = thread::spawn(move || {
+        reader_component.with_client(|client| {
+            let client = client.expect("known STUN client missing");
+            assert_eq!(client.agent_addr(), known_agent);
+            reader_step_tx.send(Step::ReaderHasLock).unwrap();
+            release_reader_rx.recv().unwrap();
+            assert_eq!(client.agent_addr(), known_agent);
+        });
+    });
+    assert_eq!(
+        step_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+        Step::ReaderHasLock
+    );
+
+    let reinit_step_tx = step_tx.clone();
+    let reinit = tokio::task::spawn_blocking(move || {
+        reinit_step_tx.send(Step::ReinitStarted).unwrap();
+        new_bind.with_components(|components, iface| {
+            components.with(|component: &StunClientComponent| component.reinit(iface))
+        });
+        reinit_step_tx.send(Step::ReinitFinished).unwrap();
+    });
+    assert_eq!(
+        step_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+        Step::ReinitStarted
+    );
+    assert_eq!(
+        step_rx.recv_timeout(Duration::from_millis(50)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    );
+
+    release_reader_tx.send(()).unwrap();
+    reader.join().unwrap();
+    assert_eq!(
+        step_rx.recv_timeout(Duration::from_secs(3)).unwrap(),
+        Step::ReinitFinished
+    );
+    reinit.await.unwrap();
 }
 
 #[tokio::test(start_paused = true)]
-async fn stun_clients_retry_lookup_after_transient_failure() {
-    let manager = InterfaceManager::global().clone();
-    let bind = manager
+async fn stun_client_retries_lookup_after_transient_failure() {
+    let interface_manager = InterfaceManager::global().clone();
+    let bind = interface_manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
         .await;
     let iface = bind.borrow();
     let stun = StunRouterComponent::new(iface.downgrade());
     let agent: SocketAddr = "192.0.2.2:20004".parse().unwrap();
     let resolver = RecoveringResolver::new(agent);
-    let clients = StunClientsComponent::new(
+    let stun_component = StunClientComponent::new(
         iface.downgrade(),
         stun.router(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::empty(),
+        None,
         None,
     );
 
     wait_for_recovering_lookup_count(&resolver, 1)
         .await
         .unwrap();
-    assert_eq!(clients.with_clients(|clients| clients.len()), 0);
+    assert!(stun_component.with_client(|client| client.is_none()));
 
     tokio::task::yield_now().await;
     tokio::time::advance(Duration::from_secs(10)).await;
     wait_for_recovering_lookup_count(&resolver, 2)
         .await
         .unwrap();
-    wait_for_client_count(&clients, 1).await.unwrap();
+    wait_for_client(&stun_component).await.unwrap();
 
-    assert!(clients.with_clients(|clients| clients.contains_key(&agent)));
+    assert!(
+        stun_component
+            .with_client(|client| client.is_some_and(|client| client.agent_addr() == agent))
+    );
 }
 
 #[tokio::test(start_paused = true)]
-async fn stun_clients_retry_lookup_after_timeout() {
-    let manager = InterfaceManager::global().clone();
-    let bind = manager
+async fn stun_client_retries_lookup_after_timeout() {
+    let interface_manager = InterfaceManager::global().clone();
+    let bind = interface_manager
         .bind(test_bind_uri(), Arc::new(DEFAULT_IO_FACTORY))
         .await;
     let iface = bind.borrow();
     let stun = StunRouterComponent::new(iface.downgrade());
     let agent: SocketAddr = "192.0.2.3:20004".parse().unwrap();
     let resolver = TimeoutThenRecoveringResolver::new(agent);
-    let clients = StunClientsComponent::new(
+    let stun_component = StunClientComponent::new(
         iface.downgrade(),
         stun.router(),
         Arc::new(resolver.clone()),
         "stun.example:20004",
-        std::iter::empty(),
+        None,
         None,
     );
 
@@ -301,8 +411,11 @@ async fn stun_clients_retry_lookup_after_timeout() {
     tokio::time::advance(Duration::from_secs(10)).await;
     tokio::task::yield_now().await;
     tokio::time::advance(Duration::from_secs(10)).await;
-    wait_for_client_count(&clients, 1).await.unwrap();
+    wait_for_client(&stun_component).await.unwrap();
 
-    assert_eq!(resolver.lookup_count(), 2);
-    assert!(clients.with_clients(|clients| clients.contains_key(&agent)));
+    assert!(resolver.lookup_count() >= 2);
+    assert!(
+        stun_component
+            .with_client(|client| client.is_some_and(|client| client.agent_addr() == agent))
+    );
 }


### PR DESCRIPTION
修复 rebind 后 STUN 无法恢复，以及多个 STUN client 干扰 NAT 探测的问题。

- rebind 后重新查询 DNS 并重建 STUN client，避免继续使用旧缓存。
- 每个 interface 只维护一个 STUN client。同一集群的多个 Agent 共用一个 socket 会干扰 NAT 探测；NAT 探测必须使用实际绑定端口，因为部分服务器只开放指定端口。