### PR TITLE
fix: correct anti-amplification credit

### DIFF
--- a/dquic/src/server.rs
+++ b/dquic/src/server.rs
@@ -30,7 +30,7 @@ use qconnection::{
 use qevent::telemetry::QLog;
 use qinterface::{
     BindInterface,
-    component::route::{QuicRouter, Way},
+    component::route::{QuicRouter, ReceivedPacket, Way},
     io::ProductIO,
     manager::InterfaceManager,
 };
@@ -434,7 +434,11 @@ impl QuicListeners {
         target = "dquic", level = "debug", skip_all,
         fields(%bind_uri, %pathway, %link, odcid=tracing::field::Empty, server_name=tracing::field::Empty)
     )]
-    pub(crate) fn try_accept_connection(&self, packet: Packet, (bind_uri, pathway, link): Way) {
+    pub(crate) fn try_accept_connection(
+        &self,
+        (packet, datagram_size): ReceivedPacket,
+        (bind_uri, pathway, link): Way,
+    ) {
         if let Err(error) =
             qinterface::component::route::validate_received_way(&(bind_uri.clone(), pathway, link))
         {
@@ -498,7 +502,9 @@ impl QuicListeners {
         let local_endpoints = self.network.local_endpoints.clone();
 
         let try_accept_connection = async move {
-            quic_router.deliver(packet, (bind_uri, pathway, link)).await;
+            quic_router
+                .deliver((packet, datagram_size), (bind_uri, pathway, link))
+                .await;
 
             match connection.server_name().await {
                 Ok(server_name) => {
@@ -981,10 +987,15 @@ mod path_admissibility_tests {
             link,
         );
 
-        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+        listeners.try_accept_connection((initial_packet(dcid), Some(1200)), way.clone());
 
         assert_eq!(listeners.backlog.available_permits(), 1);
-        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
+        assert!(
+            router
+                .try_deliver((initial_packet(dcid), None), way)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1002,9 +1013,14 @@ mod path_admissibility_tests {
         let link = Link::new(local, remote);
         let way = (BindUri::from(local), Pathway::from(link), link);
 
-        listeners.try_accept_connection(initial_packet(dcid), way.clone());
+        listeners.try_accept_connection((initial_packet(dcid), Some(1200)), way.clone());
 
         assert_eq!(listeners.backlog.available_permits(), 1);
-        assert!(router.try_deliver(initial_packet(dcid), way).await.is_err());
+        assert!(
+            router
+                .try_deliver((initial_packet(dcid), None), way)
+                .await
+                .is_err()
+        );
     }
 }

--- a/qbase/src/packet/io.rs
+++ b/qbase/src/packet/io.rs
@@ -903,5 +903,23 @@ mod tests {
             ]
             .as_slice()
         );
+
+        let mut padded = BytesMut::from(&buffer[..sent_bytes]);
+        padded.resize(1200, 0);
+        let Packet::Data(packet) = PacketReader::new(padded, 8).next().unwrap().unwrap() else {
+            panic!("expected Initial packet");
+        };
+        assert_eq!(packet.bytes.len(), sent_bytes);
+
+        let mut coalesced = BytesMut::from(&buffer[..sent_bytes]);
+        coalesced.extend_from_slice(&buffer[..sent_bytes]);
+        let mut packets = PacketReader::new(coalesced, 8);
+        let Packet::Data(_first) = packets.next().unwrap().unwrap() else {
+            panic!("expected first Initial packet");
+        };
+        let Packet::Data(_second) = packets.next().unwrap().unwrap() else {
+            panic!("expected second Initial packet");
+        };
+        assert!(packets.next().is_none());
     }
 }

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -898,7 +898,7 @@ mod tests {
 
     async fn route_exists(router: &Arc<QuicRouter>, dcid: ConnectionId, way: Way) -> bool {
         router
-            .try_deliver(test_routed_packet(dcid), way)
+            .try_deliver((test_routed_packet(dcid), None), way)
             .await
             .is_ok()
     }

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -245,11 +245,11 @@ impl Path {
         &self,
         epoch: Epoch,
         pn: u64,
-        size: usize,
+        datagram_size: Option<usize>,
         packet_content: PacketContent,
     ) {
-        self.anti_amplifier.on_rcvd(size);
-        if size > 0 {
+        if let Some(datagram_size) = datagram_size {
+            self.anti_amplifier.on_rcvd(datagram_size);
             self.status.release_anti_amplification_limit();
         }
         self.idle_timer.on_rcvd(packet_content);

--- a/qconnection/src/path/aa.rs
+++ b/qconnection/src/path/aa.rs
@@ -117,7 +117,56 @@ impl<const N: usize> AntiAmplifier<N> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
+    use qbase::packet::{Packet, PacketReader};
+
     use super::*;
+
+    #[test]
+    fn udp_bytes_after_initial_length_count_toward_amplification_credit() {
+        const INITIAL_PACKET_SIZE: usize = 290;
+        const DATAGRAM_SIZE: usize = 1200;
+
+        // The two-byte Length field is 272 (0x110 with the 01 varint prefix).
+        // With the 18-byte long header, only the first 290 bytes belong to the
+        // Initial packet. The remaining UDP payload is deliberately outside it.
+        let mut datagram = BytesMut::from(
+            &[
+                0xc0, // Initial, packet number length 1
+                0x00, 0x00, 0x00, 0x01, // QUIC v1
+                8,    // DCID length
+                0, 1, 2, 3, 4, 5, 6, 7, // DCID
+                0, // SCID length
+                0, // token length
+                0x41, 0x10, // Length = 272
+            ][..],
+        );
+        datagram.resize(INITIAL_PACKET_SIZE, 0);
+        datagram.resize(DATAGRAM_SIZE, 0);
+        let datagram_size = datagram.len();
+
+        let Packet::Data(initial) = PacketReader::new(datagram, 8)
+            .next()
+            .expect("datagram contains an Initial packet")
+            .expect("Initial packet is parseable")
+        else {
+            panic!("expected an Initial packet");
+        };
+
+        assert_eq!(initial.bytes.len(), INITIAL_PACKET_SIZE);
+        assert_eq!(datagram_size, DATAGRAM_SIZE);
+
+        let anti_amplifier = AntiAmplifier::<3>::new(ArcSendWaker::new());
+        anti_amplifier.on_rcvd(datagram_size);
+
+        assert_eq!(anti_amplifier.balance(), Ok(Some(DATAGRAM_SIZE * 3)));
+        assert_ne!(
+            anti_amplifier.balance(),
+            Ok(Some(INITIAL_PACKET_SIZE * 3)),
+            "credit must not be derived from the Initial packet Length field"
+        );
+    }
+
     #[test]
     fn test_deposit_and_poll_apply() {
         let waker = ArcSendWaker::new();

--- a/qconnection/src/space/data.rs
+++ b/qconnection/src/space/data.rs
@@ -50,11 +50,17 @@ use crate::{
 
 pub type CipherZeroRttPacket = CipherPacket<ZeroRttHeader>;
 pub type PlainZeroRttPacket = PlainPacket<ZeroRttHeader>;
-pub type ReceivedZeroRttFrom = (CipherZeroRttPacket, (BindUri, Pathway, Link));
+pub type ReceivedZeroRttFrom = (
+    (CipherZeroRttPacket, Option<usize>),
+    (BindUri, Pathway, Link),
+);
 
 pub type CipherOneRttPacket = CipherPacket<OneRttHeader>;
 pub type PlainOneRttPacket = PlainPacket<OneRttHeader>;
-pub type ReceivedOneRttFrom = (CipherOneRttPacket, (BindUri, Pathway, Link));
+pub type ReceivedOneRttFrom = (
+    (CipherOneRttPacket, Option<usize>),
+    (BindUri, Pathway, Link),
+);
 
 pub struct DataSpace {
     zero_rtt_keys: ArcZeroRttKeys,
@@ -418,7 +424,7 @@ fn frame_dispathcer(
 }
 
 async fn parse_normal_zero_rtt_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedZeroRttFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedZeroRttFrom,
     space: &DataSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, Type, &Path),
@@ -456,13 +462,13 @@ async fn parse_normal_zero_rtt_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Data),
     );
-    path.on_packet_rcvd(Epoch::Data, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Data, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
 
 async fn parse_normal_one_rtt_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedOneRttFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedOneRttFrom,
     space: &DataSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, Type, &Path),
@@ -503,7 +509,7 @@ async fn parse_normal_one_rtt_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Data),
     );
-    path.on_packet_rcvd(Epoch::Data, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Data, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
@@ -605,7 +611,7 @@ pub async fn deliver_and_parse_packets(
     drop(components);
     zeor_rtt_packets.close();
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = one_rtt_packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = one_rtt_packets.recv().await {
         if let Some(ccf) = parse_closing_one_rtt_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/space/handshake.rs
+++ b/qconnection/src/space/handshake.rs
@@ -34,7 +34,7 @@ use crate::{
 
 pub type CipherHanshakePacket = CipherPacket<HandshakeHeader>;
 pub type PlainHandshakePacket = PlainPacket<HandshakeHeader>;
-pub type ReceivedFrom = (CipherHanshakePacket, Way);
+pub type ReceivedFrom = ((CipherHanshakePacket, Option<usize>), Way);
 
 pub struct HandshakeSpace {
     keys: ArcKeys,
@@ -182,7 +182,7 @@ fn frame_dispathcer<'a>(
 }
 
 async fn parse_normal_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedFrom,
     space: &HandshakeSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, &Path),
@@ -224,7 +224,7 @@ async fn parse_normal_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Handshake),
     );
-    path.on_packet_rcvd(Epoch::Handshake, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Handshake, packet.pn(), datagram_size, packet_content);
 
     Result::<(), Error>::Ok(())
 }
@@ -290,7 +290,7 @@ pub async fn deliver_and_parse_packets(
     // Release the primary connection state
     drop(components);
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = packets.recv().await {
         if let Some(ccf) = parse_closing_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/space/initial.rs
+++ b/qconnection/src/space/initial.rs
@@ -42,7 +42,7 @@ use crate::{
 
 pub type CipherInitialPacket = CipherPacket<InitialHeader>;
 pub type PlainInitialPacket = PlainPacket<InitialHeader>;
-pub type ReceivedFrom = (CipherInitialPacket, Way);
+pub type ReceivedFrom = ((CipherInitialPacket, Option<usize>), Way);
 
 pub struct InitialSpace {
     keys: ArcKeys,
@@ -184,7 +184,7 @@ fn frame_dispathcer<'a>(
 }
 
 async fn parse_normal_packet(
-    (packet, (bind_uri, pathway, link)): ReceivedFrom,
+    ((packet, datagram_size), (bind_uri, pathway, link)): ReceivedFrom,
     space: &InitialSpace,
     components: &Components,
     dispatch_frame: impl Fn(Frame, &Path),
@@ -255,7 +255,7 @@ async fn parse_normal_packet(
         packet_content.is_ack_eliciting(),
         path.cc().get_pto(Epoch::Initial),
     );
-    path.on_packet_rcvd(Epoch::Initial, packet.pn(), packet.size(), packet_content);
+    path.on_packet_rcvd(Epoch::Initial, packet.pn(), datagram_size, packet_content);
 
     // Negotiate handshake path
     if paths.assign_handshake_path(&path, remote_cids, *packet.scid()) {
@@ -336,7 +336,7 @@ pub async fn deliver_and_parse_packets(
     // Release the primary connection state
     drop(components);
 
-    while let Some((packet, (_bind_uri, pathway, _link))) = packets.recv().await {
+    while let Some(((packet, _), (_bind_uri, pathway, _link))) = packets.recv().await {
         if let Some(ccf) = parse_closing_packet(&space, packet) {
             event_broker.emit(Event::Closed(ccf));
         }

--- a/qconnection/src/termination.rs
+++ b/qconnection/src/termination.rs
@@ -233,7 +233,7 @@ mod tests {
 
     async fn route_exists(router: &Arc<QuicRouter>, dcid: ConnectionId) -> bool {
         router
-            .try_deliver(test_routed_packet(dcid), test_way())
+            .try_deliver((test_routed_packet(dcid), None), test_way())
             .await
             .is_ok()
     }

--- a/qinterface/src/component/route.rs
+++ b/qinterface/src/component/route.rs
@@ -30,11 +30,13 @@ pub use handler::PacketHandler;
 pub use packet::{CipherPacket, PlainPacket};
 pub use qbase::packet::Packet;
 pub use queue::RcvdPacketQueue;
+/// A parsed QUIC packet paired with its UDP datagram size when it owns receive accounting.
+pub type ReceivedPacket<P = Packet> = (P, Option<usize>);
 
 #[derive(Debug)]
 pub struct QuicRouter {
     table: DashMap<Signpost, Arc<RcvdPacketQueue>>,
-    on_unrouted: handler::PacketHandler<Packet>,
+    on_unrouted: handler::PacketHandler<ReceivedPacket>,
 }
 
 impl QuicRouter {
@@ -90,18 +92,22 @@ impl QuicRouter {
     }
 
     #[allow(clippy::result_large_err)]
-    pub async fn try_deliver(&self, packet: Packet, way: Way) -> Result<(), (Packet, Way)> {
-        match self.find_entry(&packet, &way.2) {
+    pub async fn try_deliver(
+        &self,
+        received: ReceivedPacket,
+        way: Way,
+    ) -> Result<(), (ReceivedPacket, Way)> {
+        match self.find_entry(&received.0, &way.2) {
             Some(rcvd_pkt_q) => {
-                rcvd_pkt_q.deliver(packet, way).await;
+                rcvd_pkt_q.deliver(received, way).await;
                 Ok(())
             }
-            None => Err((packet, way)),
+            None => Err((received, way)),
         }
     }
 
-    pub async fn deliver(&self, packet: Packet, way: Way) {
-        let rcvd_pkt_q = match self.find_entry(&packet, &way.2) {
+    pub async fn deliver(&self, received: ReceivedPacket, way: Way) {
+        let rcvd_pkt_q = match self.find_entry(&received.0, &way.2) {
             Some(rcvd_pkt_q) => rcvd_pkt_q,
             None => {
                 // For packets that cannot be routed, this likely indicates a new connection.
@@ -114,21 +120,21 @@ impl QuicRouter {
                 };
                 // Therefore, we retry routing here to allow thread B to route its packet
                 // to the connection created by thread A, instead of creating another new connection.
-                match self.find_entry(&packet, &way.2) {
+                match self.find_entry(&received.0, &way.2) {
                     Some(rcvd_pkt_q) => rcvd_pkt_q,
                     None => {
-                        (on_unrouted)(packet, way);
+                        (on_unrouted)(received, way);
                         return;
                     }
                 }
             }
         };
-        rcvd_pkt_q.deliver(packet, way).await;
+        rcvd_pkt_q.deliver(received, way).await;
     }
 
     pub fn on_connectless_packets<S>(&self, sink: S) -> bool
     where
-        S: Fn(Packet, Way) + Send + 'static,
+        S: Fn(ReceivedPacket, Way) + Send + 'static,
     {
         let mut on_unrouted = self.on_unrouted.lock();
         if on_unrouted.is_some() {

--- a/qinterface/src/component/route/queue.rs
+++ b/qinterface/src/component/route/queue.rs
@@ -6,9 +6,9 @@ use qbase::{
     util::BoundQueue,
 };
 
-use crate::component::route::{CipherPacket, Way};
+use crate::component::route::{CipherPacket, ReceivedPacket, Way};
 
-type PacketQueue<P> = BoundQueue<(CipherPacket<P>, Way)>;
+type PacketQueue<P> = BoundQueue<(ReceivedPacket<CipherPacket<P>>, Way)>;
 
 // 需要一个四元组，pathway + src + dst
 #[derive(Debug)]
@@ -60,24 +60,24 @@ impl RcvdPacketQueue {
     }
 
     /// A per-connection queue must never backpressure the shared UDP receive loop.
-    pub async fn deliver(&self, packet: Packet, way: Way) {
+    pub async fn deliver(&self, (packet, datagram_size): ReceivedPacket, way: Way) {
         match packet {
             Packet::Data(packet) => match packet.header {
                 DataHeader::Long(long::DataHeader::Initial(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.initial.try_send((packet, way));
+                    _ = self.initial.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Long(long::DataHeader::Handshake(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.handshake.try_send((packet, way));
+                    _ = self.handshake.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Long(long::DataHeader::ZeroRtt(header)) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.zero_rtt.try_send((packet, way));
+                    _ = self.zero_rtt.try_send(((packet, datagram_size), way));
                 }
                 DataHeader::Short(header) => {
                     let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-                    _ = self.one_rtt.try_send((packet, way));
+                    _ = self.one_rtt.try_send(((packet, datagram_size), way));
                 }
             },
             Packet::VN(_vn) => {}
@@ -124,9 +124,10 @@ mod tests {
     async fn deliver_enqueues_when_capacity_is_available() {
         let queue = RcvdPacketQueue::new();
 
-        queue.deliver(initial_packet(), way()).await;
+        queue.deliver((initial_packet(), Some(1200)), way()).await;
 
-        assert!(queue.initial().recv().await.is_some());
+        let ((_packet, datagram_size), _) = queue.initial().recv().await.unwrap();
+        assert_eq!(datagram_size, Some(1200));
     }
 
     #[tokio::test]
@@ -140,7 +141,7 @@ mod tests {
                 unreachable!()
             };
             let packet = CipherPacket::new(header, packet.bytes, packet.offset);
-            match queue.initial.try_send((packet, way())) {
+            match queue.initial.try_send(((packet, Some(1200)), way())) {
                 Ok(()) => {}
                 Err(error) if error.is_full() => break,
                 Err(error) => panic!("queue closed while filling it: {error}"),
@@ -149,7 +150,7 @@ mod tests {
 
         tokio::time::timeout(
             Duration::from_millis(25),
-            queue.deliver(initial_packet(), way()),
+            queue.deliver((initial_packet(), Some(1200)), way()),
         )
         .await
         .expect("routing must not wait for one connection's full queue");

--- a/qtraversal/src/route.rs
+++ b/qtraversal/src/route.rs
@@ -40,6 +40,12 @@ use crate::{
     packet::{ForwardHeader, StunHeader},
 };
 
+const INITIAL_MINIMUM_DATAGRAM_SIZE: usize = 1_200;
+// The QUIC packet is measured after the forwarding header is removed. Keep a
+// 100-byte budget for that header so an Initial still represents a minimum-size
+// datagram on the wire.
+const INITIAL_MINIMUM_PACKET_SIZE: usize = INITIAL_MINIMUM_DATAGRAM_SIZE - 100;
+
 #[derive(Debug, Clone)]
 pub enum Forwarder<I: RefIO + 'static> {
     Clients { stun_clients: StunClients<I> },
@@ -186,7 +192,8 @@ impl ReceiveAndDeliverPacketComponent {
                 let iface = iface_ref.iface();
                 let bind_uri = iface.bind_uri();
 
-            let deliver_quic_packet = async |pkt: BytesMut, route: Route| {
+            let deliver_quic_packet =
+                async |pkt: BytesMut, route: Route, datagram_size: usize| {
                 let Some(quic_router) = quic_router.as_ref() else {
                     return;
                 };
@@ -196,14 +203,20 @@ impl ReceiveAndDeliverPacketComponent {
                     matches!(pkt, Packet::Data(packet) if matches!(packet.header, packet::DataHeader::Long(packet::long::DataHeader::Initial(..))))
                 }
 
-                let size = pkt.len();
                 let bind_uri = bind_uri.clone();
-                for (packet, way) in PacketReader::new(pkt, 8)
+                let packet_size = pkt.len();
+                let mut datagram_size = Some(datagram_size);
+                for (received, way) in PacketReader::new(pkt, 8)
                     .flatten()
-                    .filter(move |pkt| !(is_initial_packet(pkt) && size < 1100))
-                    .map(move |pkt| (pkt, (bind_uri.clone(), route.pathway(), route.link())))
+                    .map(|packet| (packet, datagram_size.take()))
+                    .filter(move |(packet, _)| {
+                        !(is_initial_packet(packet) && packet_size < INITIAL_MINIMUM_PACKET_SIZE)
+                    })
+                    .map(move |received| {
+                        (received, (bind_uri.clone(), route.pathway(), route.link()))
+                    })
                 {
-                    quic_router.deliver(packet, way).await;
+                    quic_router.deliver(received, way).await;
                 }
             };
 
@@ -234,10 +247,11 @@ impl ReceiveAndDeliverPacketComponent {
                     };
 
                     // split_off forward header, deliver the rest as quic packet
+                    let datagram_size = pkt.len();
                     let pkt = pkt.split_off(ForwardHeader::encoding_size(&fhdr.pathway()));
                     route.seg_size = pkt.len() as _;
                     let new_route = Route::new(fhdr.pathway().flip().map(Into::into), route.line);
-                    deliver_quic_packet(pkt, new_route).await;
+                    deliver_quic_packet(pkt, new_route, datagram_size).await;
                     Ok(())
                 };
 
@@ -247,7 +261,10 @@ impl ReceiveAndDeliverPacketComponent {
                     for (pkt, hdr) in iface.recvmmsg(&mut bufs, &mut hdrs).await? {
                         match be_header(&pkt) {
                             // quic
-                            Err(_) => deliver_quic_packet(pkt, hdr).await,
+                            Err(_) => {
+                                let datagram_size = pkt.len();
+                                deliver_quic_packet(pkt, hdr, datagram_size).await
+                            }
                             // stun
                             Ok((_remain, Header::Stun(_stun_header))) => {
                                 deliver_stun_packet(pkt, hdr).await


### PR DESCRIPTION
- 抗放大额度改为按 UDP datagram 大小计算，不再使用单个 QUIC packet 大小
- 同一 datagram 包含多个 QUIC packet 时只记账一次