### PR TITLE
chore: prepare dquic v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,17 +97,17 @@ tracing-appender = "0.2"
 
 # members
 qmacro = { path = "./qmacro", version = "0.5.1" }
-qbase = { path = "./qbase", version = "0.6.1" }
+qbase = { path = "./qbase", version = "0.6.2" }
 qevent = { path = "./qevent", version = "0.6.0" }
-qudp = { path = "./qudp", version = "0.7.0-beta.1" }
-qinterface = { path = "./qinterface", version = "0.7.0-beta.3" }
+qudp = { path = "./qudp", version = "0.7.0" }
+qinterface = { path = "./qinterface", version = "0.7.0" }
 qdatagram = { path = "./qdatagram", version = "0.6.0" }
-qresolve = { path = "./qresolve", version = "0.7.0-beta.1" }
+qresolve = { path = "./qresolve", version = "0.7.0" }
 qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0-beta.5" }
+qtraversal = { path = "./qtraversal", version = "0.7.0" }
 qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.8.0-beta.2" }
-dquic = { path = "./dquic", version = "0.7.0-beta.5" }
+qconnection = { path = "./qconnection", version = "0.8.0" }
+dquic = { path = "./dquic", version = "0.7.0" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0-beta.5"
+version = "0.7.0"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbase"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 description = "Core structure of the QUIC protocol, a part of dquic"
 readme.workspace = true

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.8.0-beta.2"
+version = "0.8.0"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.0-beta.3"
+version = "0.7.0"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qresolve/Cargo.toml
+++ b/qresolve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qresolve"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 edition.workspace = true
 description = "dquic's dns abstractions"
 readme.workspace = true

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0-beta.5"
+version = "0.7.0"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qudp"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 edition.workspace = true
 description = "High-performance UDP encapsulation for QUIC"
 readme.workspace = true


### PR DESCRIPTION
## Summary

- bump the DQuic workspace to the stable `0.7.0` release line
- align internal workspace dependency versions for the stable release

## Release

- Surface: crates.io (DQuic workspace crates), stable release
- Planned tag: `v0.7.0`
- Downstream: publish dependent crates only after this release is registry-visible

## Verification

- Local tests were not run per release coordination instructions
- GitHub PR checks remain enabled
