### PR TITLE
chore(release): prepare dquic v0.7.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## [0.7.1-beta.1] - 2026-08-11
+
+### Fixed
+
+- Bound received-packet ACK journals by evicting the oldest ranges instead of
+  coupling receive-history retention to peer ACK progress.
+- Preserve path-local ACK triggers and ensure each ACK's largest packet number
+  belongs to the path that sends it.
+- Process sparse multipath ACK ranges without assuming globally contiguous
+  packet numbers.
+- Preserve the configured STUN server address through traversal handling.
+
+### Published crates
+
+- `qbase` v0.6.3-beta.1
+- `qevent` v0.6.1-beta.1
+- `qudp` v0.7.1-beta.1
+- `qinterface` v0.7.1-beta.1
+- `qdatagram` v0.6.1-beta.1
+- `qresolve` v0.8.0-beta.1
+- `qcongestion` v0.6.1-beta.1
+- `qrecovery` v0.6.1-beta.1
+- `qtraversal` v0.7.1-beta.1
+- `qconnection` v0.8.1-beta.1
+- `dquic` v0.7.1-beta.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,17 +97,17 @@ tracing-appender = "0.2"
 
 # members
 qmacro = { path = "./qmacro", version = "0.5.1" }
-qbase = { path = "./qbase", version = "0.6.3" }
-qevent = { path = "./qevent", version = "0.6.0" }
-qudp = { path = "./qudp", version = "0.7.0" }
-qinterface = { path = "./qinterface", version = "0.7.0" }
-qdatagram = { path = "./qdatagram", version = "0.6.0" }
-qresolve = { path = "./qresolve", version = "0.8.0" }
-qrecovery = { path = "./qrecovery", version = "0.6.0" }
-qtraversal = { path = "./qtraversal", version = "0.7.0" }
-qcongestion = { path = "./qcongestion", version = "0.6.0" }
-qconnection = { path = "./qconnection", version = "0.8.0" }
-dquic = { path = "./dquic", version = "0.7.0" }
+qbase = { path = "./qbase", version = "0.6.3-beta.1" }
+qevent = { path = "./qevent", version = "0.6.1-beta.1" }
+qudp = { path = "./qudp", version = "0.7.1-beta.1" }
+qinterface = { path = "./qinterface", version = "0.7.1-beta.1" }
+qdatagram = { path = "./qdatagram", version = "0.6.1-beta.1" }
+qresolve = { path = "./qresolve", version = "0.8.0-beta.1" }
+qrecovery = { path = "./qrecovery", version = "0.6.1-beta.1" }
+qtraversal = { path = "./qtraversal", version = "0.7.1-beta.1" }
+qcongestion = { path = "./qcongestion", version = "0.6.1-beta.1" }
+qconnection = { path = "./qconnection", version = "0.8.1-beta.1" }
+dquic = { path = "./dquic", version = "0.7.1-beta.1" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.0"
+version = "0.7.1-beta.1"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbase"
-version = "0.6.3"
+version = "0.6.3-beta.1"
 edition.workspace = true
 description = "Core structure of the QUIC protocol, a part of dquic"
 readme.workspace = true

--- a/qbase/src/datagram/io.rs
+++ b/qbase/src/datagram/io.rs
@@ -216,4 +216,17 @@ mod tests {
         bytes.put_slice(&[0; 15]);
         assert_eq!(be_datagram(bytes), Err(Error::InvalidStunMessage));
     }
+
+    #[test]
+    fn legacy_stun_request_is_rejected_without_panicking() {
+        // The legacy layout encoded a separate u16 message type between the
+        // nine-byte camouflage header and the transaction ID. The current
+        // layout carries the message type in the camouflage header itself.
+        let mut bytes = BytesMut::from(&[0xc2, 0, 0, 0, 0, 0, 0, 0, 0][..]);
+        bytes.put_u16(1);
+        bytes.put_slice(&[0; 16]);
+
+        assert_eq!(bytes.len(), 27);
+        assert_eq!(be_datagram(bytes), Err(Error::InvalidStunMessage));
+    }
 }

--- a/qbase/src/frame/ack.rs
+++ b/qbase/src/frame/ack.rs
@@ -153,9 +153,8 @@ impl AckFrame {
         self.ecn.take()
     }
 
-    /// Iterate through the sequence numbers of the packets acknowledged by the iterative ACK frame,
-    /// starting from the largest and going down.
-    pub fn iter(&self) -> impl Iterator<Item = RangeInclusive<u64>> + '_ {
+    /// Iterate through the acknowledged packet ranges, starting from the largest and going down.
+    pub fn iter_ranges(&self) -> impl Iterator<Item = RangeInclusive<u64>> + '_ {
         let right = self.largest.into_u64();
         let left = right - self.first_range.into_u64();
         Some(left..=right).into_iter().chain(
@@ -169,6 +168,12 @@ impl AckFrame {
                     Some(left..=right)
                 }),
         )
+    }
+
+    /// Iterate through the sequence numbers of the packets acknowledged by the ACK frame,
+    /// starting from the largest and going down.
+    pub fn iter(&self) -> impl Iterator<Item = RangeInclusive<u64>> + '_ {
+        self.iter_ranges()
     }
 }
 

--- a/qcongestion/Cargo.toml
+++ b/qcongestion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcongestion"
-version = "0.6.0"
+version = "0.6.1-beta.1"
 edition.workspace = true
 description = "Congestion control in QUIC, a part of dquic"
 readme.workspace = true

--- a/qcongestion/src/congestion.rs
+++ b/qcongestion/src/congestion.rs
@@ -111,7 +111,12 @@ impl CongestionController {
             }
             self.algorithm.on_packet_sent_cc(&sent);
         }
-        self.packet_spaces[epoch].sent_packets.push_back(sent);
+        // Pure ACK packets are neither ack-eliciting nor in flight. The peer is not required to
+        // acknowledge them, and congestion control has no loss/RTT state to derive from them, so
+        // retaining one record per packet would create an unbounded tail during one-way traffic.
+        if ack_eliciting || in_flight {
+            self.packet_spaces[epoch].sent_packets.push_back(sent);
+        }
         if in_flight {
             self.set_loss_detection_timer();
         }
@@ -646,5 +651,20 @@ mod tests {
         let pto = controller.get_pto(Epoch::Data);
         assert_eq!(space.loss_time, None);
         assert_eq!(controller.loss_detection_timer, Some(last_sent + pto));
+    }
+
+    #[test]
+    fn pure_ack_packets_do_not_accumulate_sent_records() {
+        let mut controller = controller();
+
+        for pn in 0..100_000 {
+            controller.on_packet_sent(pn, Epoch::Data, false, false, 64);
+        }
+
+        assert!(
+            controller.packet_spaces[Epoch::Data]
+                .sent_packets
+                .is_empty()
+        );
     }
 }

--- a/qcongestion/src/packets.rs
+++ b/qcongestion/src/packets.rs
@@ -182,35 +182,33 @@ impl PacketSpace {
         if self.sent_packets.is_empty() {
             return None;
         }
+        let ack_ranges = ack_frame.iter_ranges().collect::<Vec<_>>();
         let mut include_ack_eliciting = false;
         let mut largest_acked = None;
-        let mut index = self
-            .sent_packets
-            .binary_search_by(|p| p.packet_number.cmp(&ack_frame.largest()))
-            .unwrap_or_else(|i| i.saturating_sub(1));
 
-        for range in ack_frame.iter() {
-            for pn in range.rev() {
-                while index > 0 && self.sent_packets[index].packet_number > pn {
-                    index = index.saturating_sub(1);
-                }
-                if self.sent_packets[index].packet_number == pn
-                    && self.sent_packets[index].state != State::Acked
-                {
-                    algorithm.on_packet_acked(&self.sent_packets[index]);
-                    self.sent_packets[index].state = State::Acked;
-                    include_ack_eliciting |= self.sent_packets[index].ack_eliciting;
-                    largest_acked = largest_acked
-                        .map(|(n, t)| {
-                            if n < pn {
-                                (pn, self.sent_packets[index].time_sent)
-                            } else {
-                                (n, t)
-                            }
-                        })
-                        .or(Some((pn, self.sent_packets[index].time_sent)));
-                }
+        // The ACK frame may cover huge PN intervals while this path only owns a sparse subset of
+        // those packets. Walk the bounded local records instead of expanding every PN in the ACK.
+        for sent in self.sent_packets.iter_mut().rev() {
+            if sent.state == State::Acked
+                || !ack_ranges
+                    .iter()
+                    .any(|range| range.contains(&sent.packet_number))
+            {
+                continue;
             }
+
+            algorithm.on_packet_acked(&*sent);
+            sent.state = State::Acked;
+            include_ack_eliciting |= sent.ack_eliciting;
+            largest_acked = largest_acked
+                .map(|(n, t)| {
+                    if n < sent.packet_number {
+                        (sent.packet_number, sent.time_sent)
+                    } else {
+                        (n, t)
+                    }
+                })
+                .or(Some((sent.packet_number, sent.time_sent)));
         }
 
         while self
@@ -468,6 +466,33 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(lost, vec![10]);
+    }
+
+    #[test]
+    fn ack_ranges_match_sparse_sent_packets() {
+        let mut packet_space = PacketSpace::with_epoch(Epoch::Data, Duration::from_millis(25));
+        let now = Instant::now();
+        for pn in [10, 100, 1_000_000] {
+            packet_space
+                .sent_packets
+                .push_back(SentPacket::new(pn, now, true, true, 1200));
+        }
+
+        // The range contains a million packet numbers, but this path only sent three of them.
+        let ack_frame = AckFrame::new(
+            1_000_000_u32.into(),
+            0_u32.into(),
+            1_000_000_u32.into(),
+            vec![],
+            None,
+        );
+        let mut reno = new_reno();
+
+        let newly_acked = packet_space
+            .on_ack_rcvd(&ack_frame, &mut reno)
+            .expect("the sparse local records should be acknowledged");
+        assert_eq!(newly_acked.largest.0, 1_000_000);
+        assert!(packet_space.sent_packets.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/qcongestion/src/packets.rs
+++ b/qcongestion/src/packets.rs
@@ -131,10 +131,17 @@ impl RcvdRecords {
 
     /// Called when an ACK is sent.
     /// Updates the last ACK sent information and resets the `need_ack` flag.
-    pub(crate) fn on_ack_sent(&mut self, _pn: u64, _largest_acked: u64) {
-        self.largest_rcvd_packet = None;
-        self.latest_rcvd_time = None;
-        self.ack_immedietly = false;
+    pub(crate) fn on_ack_sent(&mut self, _pn: u64, largest_acked: u64) {
+        // ACK assembly uses the path-local trigger as Largest Acknowledged. If a newer packet was
+        // received while the ACK packet was being assembled, leave it pending for the next cycle.
+        if self
+            .largest_rcvd_packet
+            .is_some_and(|(largest_rcvd, _)| largest_rcvd == largest_acked)
+        {
+            self.largest_rcvd_packet = None;
+            self.latest_rcvd_time = None;
+            self.ack_immedietly = false;
+        }
     }
 }
 
@@ -483,5 +490,16 @@ mod tests {
         assert_eq!(rcvd_records.need_ack(), None);
         rcvd_records.on_pkt_rcvd(11);
         assert_eq!(rcvd_records.need_ack().unwrap().0, 15);
+    }
+
+    #[test]
+    fn sending_an_older_ack_does_not_clear_a_newer_path_trigger() {
+        let mut rcvd_records = RcvdRecords::new(Epoch::Data, Duration::ZERO);
+        rcvd_records.on_pkt_rcvd(100);
+        rcvd_records.on_pkt_rcvd(101);
+
+        rcvd_records.on_ack_sent(10, 100);
+
+        assert_eq!(rcvd_records.largest_rcvd_packet.unwrap().0, 101);
     }
 }

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.8.0"
+version = "0.8.1-beta.1"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qconnection/src/builder.rs
+++ b/qconnection/src/builder.rs
@@ -42,8 +42,7 @@ use tracing::Instrument as _;
 
 use crate::{
     ArcLocalCids, ArcReliableFrameDeque, ArcRemoteCids, CidRegistry, Components, Connection,
-    DataJournal, DataStreams, FlowController, Handshake, QuicRouterRegistry, RawHandshake,
-    SpecificComponents,
+    DataStreams, FlowController, Handshake, QuicRouterRegistry, RawHandshake, SpecificComponents,
     events::{ArcEventBroker, EmitEvent, Event},
     path::ArcPathContexts,
     space::{
@@ -593,7 +592,6 @@ fn spawn_tls_handshake(components: &Components, tx_wakers: ArcSendWakers) {
             components.parameters.clone(),
             components.data_streams.clone(),
             components.flow_ctrl.clone(),
-            components.spaces.data().journal().clone(),
             components.cid_registry.local.clone(),
             components.idle_config.clone(),
             tx_wakers,
@@ -615,7 +613,6 @@ fn tls_fin_handler(
     parameters: ArcParameters,
     data_streams: DataStreams,
     flow_ctrl: FlowController,
-    data_journal: DataJournal,
     local_cids: ArcLocalCids,
     idle_config: ArcIdleConfig,
     tx_wakers: ArcSendWakers,
@@ -624,7 +621,6 @@ fn tls_fin_handler(
         data_streams: &DataStreams,
         flow_ctrl: &FlowController,
         // datagram_flow
-        data_journal: &DataJournal,
         local_cids: &ArcLocalCids,
         idle_config: &ArcIdleConfig,
         zero_rtt_rejected: bool,
@@ -646,11 +642,6 @@ fn tls_fin_handler(
                 .get(ParameterId::ActiveConnectionIdLimit)
                 .expect("unreachable: default value will be got if the value unset"),
         )?;
-        data_journal.of_rcvd_packets().revise_max_ack_delay(
-            remote_parameters
-                .get(ParameterId::MaxAckDelay)
-                .expect("unreachable: default value will be got if the value unset"),
-        );
         idle_config.negotiate_max_idle_timeout(
             remote_parameters
                 .get(ParameterId::MaxIdleTimeout)
@@ -691,7 +682,6 @@ fn tls_fin_handler(
                 apply_parameters(
                     &data_streams,
                     &flow_ctrl,
-                    &data_journal,
                     &local_cids,
                     &idle_config,
                     zero_rtt_rejected,
@@ -711,7 +701,6 @@ fn tls_fin_handler(
                 apply_parameters(
                     &data_streams,
                     &flow_ctrl,
-                    &data_journal,
                     &local_cids,
                     &idle_config,
                     zero_rtt_rejected,

--- a/qconnection/src/space.rs
+++ b/qconnection/src/space.rs
@@ -198,15 +198,13 @@ impl ReceiveFrame<AckFrame> for AckInitialSpace {
         let mut rotate_guard = self.sent_journal.rotate();
         rotate_guard.update_largest(&ack_frame)?;
 
-        let acked = ack_frame.iter().flat_map(|r| r.rev()).collect::<Vec<_>>();
+        let acked = rotate_guard.acked_packet_numbers(&ack_frame);
         qevent::event!(PacketsAcked {
             packet_number_space: qbase::Epoch::Initial,
             packet_nubers: acked.clone(),
         });
-        for pn in acked {
-            for frame in rotate_guard.on_packet_acked(pn) {
-                self.crypto_stream_outgoing.on_data_acked(&frame);
-            }
+        for frame in rotate_guard.on_packets_acked(&ack_frame) {
+            self.crypto_stream_outgoing.on_data_acked(&frame);
         }
 
         Ok(())
@@ -234,15 +232,13 @@ impl ReceiveFrame<AckFrame> for AckHandshakeSpace {
         let mut rotate_guard = self.sent_journal.rotate();
         rotate_guard.update_largest(&ack_frame)?;
 
-        let acked = ack_frame.iter().flat_map(|r| r.rev()).collect::<Vec<_>>();
+        let acked = rotate_guard.acked_packet_numbers(&ack_frame);
         qevent::event!(PacketsAcked {
             packet_number_space: qbase::Epoch::Handshake,
             packet_nubers: acked.clone(),
         });
-        for pn in acked {
-            for frame in rotate_guard.on_packet_acked(pn) {
-                self.crypto_stream_outgoing.on_data_acked(&frame);
-            }
+        for frame in rotate_guard.on_packets_acked(&ack_frame) {
+            self.crypto_stream_outgoing.on_data_acked(&frame);
         }
 
         Ok(())
@@ -276,25 +272,23 @@ impl ReceiveFrame<AckFrame> for AckDataSpace {
         let mut rotate_guard = self.send_journal.rotate();
         rotate_guard.update_largest(&ack_frame)?;
 
-        let acked = ack_frame.iter().flat_map(|r| r.rev()).collect::<Vec<_>>();
+        let acked = rotate_guard.acked_packet_numbers(&ack_frame);
         qevent::event!(PacketsAcked {
             packet_number_space: qbase::Epoch::Data,
             packet_nubers: acked.clone(),
         });
-        for pn in acked {
-            for frame in rotate_guard.on_packet_acked(pn) {
-                match frame {
-                    GuaranteedFrame::Stream(stream_frame) => {
-                        self.data_streams.on_data_acked(stream_frame)
-                    }
-                    GuaranteedFrame::Crypto(crypto_frame) => {
-                        self.crypto_stream_outgoing.on_data_acked(&crypto_frame)
-                    }
-                    GuaranteedFrame::Reliable(ReliableFrame::StreamCtl(
-                        StreamCtlFrame::ResetStream(reset_frame),
-                    )) => self.data_streams.on_reset_acked(reset_frame),
-                    _ => { /* nothing to do */ }
+        for frame in rotate_guard.on_packets_acked(&ack_frame) {
+            match frame {
+                GuaranteedFrame::Stream(stream_frame) => {
+                    self.data_streams.on_data_acked(stream_frame)
                 }
+                GuaranteedFrame::Crypto(crypto_frame) => {
+                    self.crypto_stream_outgoing.on_data_acked(&crypto_frame)
+                }
+                GuaranteedFrame::Reliable(ReliableFrame::StreamCtl(
+                    StreamCtlFrame::ResetStream(reset_frame),
+                )) => self.data_streams.on_reset_acked(reset_frame),
+                _ => { /* nothing to do */ }
             }
         }
         Ok(())

--- a/qconnection/src/space/data.rs
+++ b/qconnection/src/space/data.rs
@@ -132,10 +132,6 @@ impl DataSpace {
         self.zero_rtt_keys.clone()
     }
 
-    pub(crate) fn journal(&self) -> &DataJournal {
-        &self.journal
-    }
-
     pub fn tracker(
         &self,
         crypto_stream: CryptoStream,
@@ -355,11 +351,9 @@ fn frame_dispathcer(
         event_broker.clone(),
     );
     let event_broker = event_broker.clone();
-    let rcvd_joural = space.journal.of_rcvd_packets();
     move |frame: Frame, pty: packet::Type, path: &Path| match frame {
         Frame::Ack(f) => {
             path.cc().on_ack_rcvd(Epoch::Data, &f);
-            rcvd_joural.on_rcvd_ack(&f);
             _ = ack_frames_entry.send(f)
         }
         Frame::NewToken(f) => _ = new_token_frames_entry.send(f),

--- a/qconnection/src/space/handshake.rs
+++ b/qconnection/src/space/handshake.rs
@@ -141,11 +141,9 @@ fn frame_dispathcer<'a>(
     let ack_frames_entry = OnceLock::new();
     let inform_cc = components.quic_handshake.status();
     let event_broker = event_broker.clone();
-    let rcvd_joural = space.journal.of_rcvd_packets();
     move |frame: Frame, path: &Path| match frame {
         Frame::Ack(f) => {
             path.cc().on_ack_rcvd(Epoch::Handshake, &f);
-            rcvd_joural.on_rcvd_ack(&f);
             _ = ack_frames_entry
                 .get_or_init(|| {
                     let (entry, rcvd_ack_frames) = mpsc::unbounded_channel();

--- a/qconnection/src/space/initial.rs
+++ b/qconnection/src/space/initial.rs
@@ -144,11 +144,9 @@ fn frame_dispathcer<'a>(
     let crypto_frames_entry = OnceLock::new();
     let ack_frames_entry = OnceLock::new();
     let event_broker = event_broker.clone();
-    let rcvd_joural = space.journal.of_rcvd_packets();
     move |frame: Frame, path: &Path| match frame {
         Frame::Ack(f) => {
             path.cc().on_ack_rcvd(Epoch::Initial, &f);
-            rcvd_joural.on_rcvd_ack(&f);
             _ = ack_frames_entry
                 .get_or_init(|| {
                     let (entry, rcvd_ack_frames) = mpsc::unbounded_channel();

--- a/qdatagram/Cargo.toml
+++ b/qdatagram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdatagram"
-version = "0.6.0"
+version = "0.6.1-beta.1"
 edition.workspace = true
 description = "Datagram transmission of dquic"
 readme.workspace = true

--- a/qevent/Cargo.toml
+++ b/qevent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qevent"
-version = "0.6.0"
+version = "0.6.1-beta.1"
 edition.workspace = true
 description = "qlog implementation"
 readme.workspace = true

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.0"
+version = "0.7.1-beta.1"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qrecovery/Cargo.toml
+++ b/qrecovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qrecovery"
-version = "0.6.0"
+version = "0.6.1-beta.1"
 edition.workspace = true
 description = "The reliable transport part of QUIC, a part of dquic"
 readme.workspace = true

--- a/qrecovery/src/journal/rcvd.rs
+++ b/qrecovery/src/journal/rcvd.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    ops::Range,
     sync::{Arc, RwLock},
 };
 
@@ -8,176 +8,149 @@ use qbase::{
     frame::AckFrame,
     net::tx::Signals,
     packet::{InvalidPacketNumber, Package, PacketContent, PacketNumber, PacketWriter},
-    util::{IndexDeque, IndexError},
     varint::{VARINT_MAX, VarInt},
 };
 use tokio::time::{Duration, Instant};
 
-/// 收包记录有以下几种状态
-/// - Empty：收包记录为空，未收到该包
-/// - PacketReceived：（收包时间，最晚ack时间，过期时间）, 如果路径没有驱动 ack，由这里驱动
-/// - AckSent：（ack_eliciting，收包时间,淘汰时间，确认了这个包的包号集合），如果set里的任意包号被确认了，则转换成 AckConfirmed 状态
-/// - AckConfirmed：（ack_eliciting，收包时间，淘汰时间）
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-enum State {
-    #[default]
-    Empty,
-    PacketReceived(Instant, Option<Instant>, Instant),
-    AckSent(bool, Instant, Instant, HashSet<u64>),
-    AckConfirmed(bool, Instant, Instant),
+// A range is 16 bytes on 64-bit targets. This bound is deliberately wider than the number of
+// ranges that normally fit in one ACK packet so multipath reordering does not immediately retire
+// slow-path packets, while still providing a connection-local memory limit.
+const MAX_TRACKED_ACK_RANGES: usize = 256;
+
+/// Received packet numbers represented as sorted, disjoint, half-open ranges.
+///
+/// The range set is intentionally independent from ACK delivery. An ACK can be lost, arrive on a
+/// different path, or never be elicited by the peer; none of those events may make memory safety
+/// depend on peer cooperation.
+#[derive(Debug, Clone, Default)]
+struct ReceivedPacketRanges {
+    ranges: Vec<Range<u64>>,
+    // Packet numbers below this boundary are never accepted again. It advances only when the hard
+    // range bound is reached and the oldest range is evicted.
+    retired_before: u64,
+    largest_received: Option<(u64, Instant)>,
 }
 
-impl State {
-    // 是否要打包到 ack frame 中，如果需要，PacketReceived 状态转换成 AckSent 状态， AckSent 状态记录 pn
-    fn track_packet_in_ack_frame(&mut self, pn: u64) -> bool {
-        match self {
-            State::PacketReceived(recv_time, latest_ack_time, expire_time) => {
-                *self = State::AckSent(
-                    latest_ack_time.is_some(),
-                    *recv_time,
-                    *expire_time,
-                    [pn].into(),
-                );
-                true
-            }
-            State::AckSent(_, _, _, pns) => {
-                pns.insert(pn);
-                true
-            }
-            State::AckConfirmed(_, _, _) => true,
-            State::Empty => false,
-        }
+impl ReceivedPacketRanges {
+    fn contains(&self, pn: u64) -> bool {
+        let index = self.ranges.partition_point(|range| range.end <= pn);
+        self.ranges
+            .get(index)
+            .is_some_and(|range| range.start <= pn && pn < range.end)
     }
 
-    fn could_expire(&self, now: Instant) -> bool {
-        match self {
-            State::Empty => true,
-            State::AckConfirmed(ack_eliciting, _, expire_time) => {
-                !ack_eliciting || *expire_time < now
-            }
-            _ => false,
+    fn insert(&mut self, pn: u64, received_at: Instant) -> bool {
+        if pn < self.retired_before || self.contains(pn) {
+            return false;
         }
+
+        let index = self.ranges.partition_point(|range| range.end < pn);
+        let inserted_end = pn + 1;
+        if index < self.ranges.len() && self.ranges[index].end == pn {
+            self.ranges[index].end = inserted_end;
+            if index + 1 < self.ranges.len()
+                && self.ranges[index + 1].start <= self.ranges[index].end
+            {
+                let next_end = self.ranges[index + 1].end;
+                self.ranges[index].end = self.ranges[index].end.max(next_end);
+                self.ranges.remove(index + 1);
+            }
+        } else if index < self.ranges.len() && self.ranges[index].start == inserted_end {
+            self.ranges[index].start = pn;
+        } else {
+            self.ranges.insert(index, pn..inserted_end);
+        }
+
+        if self
+            .largest_received
+            .is_none_or(|(largest, _)| pn > largest)
+        {
+            self.largest_received = Some((pn, received_at));
+        }
+
+        if self.ranges.len() > MAX_TRACKED_ACK_RANGES {
+            let evicted = self.ranges.remove(0);
+            self.retired_before = self.retired_before.max(evicted.end);
+        }
+        true
+    }
+
+    fn largest(&self) -> Option<(u64, Instant)> {
+        self.largest_received
+    }
+
+    fn range_containing(&self, pn: u64) -> Option<usize> {
+        let index = self.ranges.partition_point(|range| range.end <= pn);
+        self.ranges
+            .get(index)
+            .filter(|range| range.start <= pn && pn < range.end)
+            .map(|_| index)
     }
 }
 
-/// 纯碎的一个收包记录，主要用于：
-/// - 记录包有无收到
-/// - 根据某个largest pktno，生成ack frame（ack frame不能超过buf大小）
-/// - 确定记录不再需要，可以被丢弃，滑走
+/// 记录已经收到的 packet，并生成 ACK frame。
+///
+/// 接收状态按 ACK range 保存，而不是为每个 PN 保存一个状态。ACK frame 的构造是只读操作；
+/// ACK 调度和发送后的状态更新由各路径的拥塞控制器负责。
 #[derive(Debug, Default)]
 struct RcvdJournal {
-    queue: IndexDeque<State, VARINT_MAX>,
-    max_ack_delay: Option<Duration>,
-    packet_include_ack: HashSet<u64>,
-    earliest_not_ack_time: Option<(u64, Instant)>,
+    packets: ReceivedPacketRanges,
 }
 
 impl RcvdJournal {
-    fn with_capacity(capacity: usize, max_ack_delay: Option<Duration>) -> Self {
+    fn with_capacity(capacity: usize, _max_ack_delay: Option<Duration>) -> Self {
         Self {
-            queue: IndexDeque::with_capacity(capacity),
-            max_ack_delay,
-            packet_include_ack: HashSet::new(),
-            earliest_not_ack_time: None,
+            packets: ReceivedPacketRanges {
+                ranges: Vec::with_capacity(capacity.min(MAX_TRACKED_ACK_RANGES)),
+                ..Default::default()
+            },
         }
     }
 
-    fn decode_pn(&mut self, pkt_number: PacketNumber) -> Result<u64, InvalidPacketNumber> {
-        let expected_pn = self.queue.largest();
+    fn decode_pn(&self, pkt_number: PacketNumber) -> Result<u64, InvalidPacketNumber> {
+        let expected_pn = self
+            .packets
+            .largest()
+            .map_or(0, |(largest, _)| largest.saturating_add(1));
         let pn = pkt_number.decode(expected_pn);
-        if pn < self.queue.offset() {
+        if pn < self.packets.retired_before {
             return Err(InvalidPacketNumber::TooOld);
         }
-
-        match self.queue.get(pn) {
-            Some(State::Empty) | None => Ok(pn),
-            _ => Err(InvalidPacketNumber::Duplicate),
+        if self.packets.contains(pn) {
+            return Err(InvalidPacketNumber::Duplicate);
         }
+        Ok(pn)
     }
 
-    fn on_rcvd_pn(&mut self, pn: u64, is_ack_eliciting: bool, pto: Duration) {
-        let now = tokio::time::Instant::now();
-        let ack_time = if is_ack_eliciting {
-            Some(now + self.max_ack_delay.unwrap_or_default())
-        } else {
-            None
-        };
-        let expire_time = now + pto * 3;
-        if let Some(record) = self.queue.get_mut(pn) {
-            // assert!(matches!(record, State::Empty));
-            *record = State::PacketReceived(now, ack_time, expire_time);
-        } else if let Err(e @ IndexError::ExceedLimit(..)) = self
-            .queue
-            .insert(pn, State::PacketReceived(now, ack_time, expire_time))
-        {
-            panic!("packet number never exceed limit: {e}")
-        }
-        if is_ack_eliciting && self.earliest_not_ack_time.is_none() {
-            self.earliest_not_ack_time = Some((pn, now));
-        }
-    }
-
-    fn on_rcvd_ack(&mut self, ack_frame: &AckFrame) {
-        let acked_pns: std::collections::HashSet<_> = ack_frame
-            .iter()
-            .flat_map(|range| range.clone())
-            .filter(|pn| self.packet_include_ack.contains(pn))
-            .collect();
-
-        self.packet_include_ack.retain(|pn| !acked_pns.contains(pn));
-
-        for record in self.queue.iter_mut() {
-            if let State::AckSent(ack_eliciting, recv_time, expire_time, pns) = record
-                && pns.iter().any(|pn| acked_pns.contains(pn))
-            {
-                *record = State::AckConfirmed(*ack_eliciting, *recv_time, *expire_time);
-            }
-        }
-        self.rotate_queue();
-    }
-
-    fn rotate_queue(&mut self) {
-        let now = tokio::time::Instant::now();
-        while self
-            .queue
-            .front()
-            .is_some_and(|(_pn, state)| state.could_expire(now))
-        {
-            self.queue.pop_front();
-        }
+    fn on_rcvd_pn(&mut self, pn: u64, _is_ack_eliciting: bool, _pto: Duration) {
+        let now = Instant::now();
+        self.packets.insert(pn, now);
     }
 
     fn gen_ack_frame_util(
-        &mut self,
-        pn: u64,
+        &self,
         largest: u64,
         rcvd_time: Instant,
         mut capacity: usize,
     ) -> Result<AckFrame, Signals> {
-        let mut pkts = self
-            .queue
-            .enumerate_mut()
-            .rev()
-            .skip_while(|(pktno, _)| *pktno > largest);
+        let Some(range_index) = self.packets.range_containing(largest) else {
+            return Err(Signals::TRANSPORT);
+        };
+        let range = &self.packets.ranges[range_index];
+        let largest = VarInt::from_u64(largest).map_err(|_| Signals::TRANSPORT)?;
+        let delay: u64 = rcvd_time
+            .elapsed()
+            .as_micros()
+            .try_into()
+            .unwrap_or(VARINT_MAX)
+            .min(VARINT_MAX);
+        let delay = VarInt::from_u64(delay).map_err(|_| Signals::TRANSPORT)?;
+        let first_range =
+            VarInt::from_u64(largest.into_u64() - range.start).map_err(|_| Signals::TRANSPORT)?;
 
-        // Minimum length with at least ACK frame type, largest, delay, range count, first_range (at least 1 byte for 0)
-        let largest = VarInt::from_u64(largest).unwrap();
-        let delay = rcvd_time.elapsed().as_micros() as u64;
-        let delay = VarInt::from_u64(delay).unwrap();
-        let mut first_range = 0_u32;
-        for (_, s) in pkts.by_ref() {
-            if s.track_packet_in_ack_frame(pn) {
-                first_range += 1;
-            } else {
-                break;
-            }
-        }
-        first_range = first_range.saturating_sub(1);
-
-        let first_range = VarInt::from(first_range);
-        // Frame type + Largest Acknowledged + First Ack Range + Ack Range Count
+        // Frame type + Largest Acknowledged + ACK Delay + ACK Range Count + First ACK Range.
         let min_len =
-            1 + largest.encoding_size() + delay.encoding_size() + first_range.encoding_size() + 1;
+            1 + largest.encoding_size() + delay.encoding_size() + 1 + first_range.encoding_size();
         if capacity < min_len {
             return Err(Signals::CONGESTION);
         }
@@ -185,107 +158,48 @@ impl RcvdJournal {
 
         fn range_count_size_increment(range_count: usize) -> usize {
             match range_count {
-                // 接下来需要2字节编码
-                len if len == (1 << 6) - 1 => 1, // 2 - 1
-                // 接下来需要4字节编码
-                len if len == (1 << 14) - 1 => 2, // 4 - 2
-                // 接下来需要8字节编码
-                len if len == (1 << 30) - 1 => 4, // 8 - 4
-                // 放不下了，不可能走到这里
+                len if len == (1 << 6) - 1 => 1,
+                len if len == (1 << 14) - 1 => 2,
+                len if len == (1 << 30) - 1 => 4,
                 _ => 0,
             }
         }
 
-        let mut ranges = vec![];
-
-        use core::ops::ControlFlow::*;
-        let (Continue((gap, ack, last_is_acked)) | Break((gap, ack, last_is_acked))) = pkts
-            .try_fold(
-                // take_while第一个被判否的元素会被消耗，如果它是gap那这里有gap=1，如果是因为迭代器没有更多元素这里gap=1也不影响
-                (1, 0, false),
-                |(gap, ack, last_is_acked), (_pktno, state)| {
-                    let range_count = ranges.len();
-                    match (last_is_acked, state.track_packet_in_ack_frame(pn)) {
-                        // 本range结束了，看看是否放得下本range，开始新的range
-                        (true, false) => {
-                            // 修正
-                            let gap = VarInt::from_u32(gap - 1);
-                            let ack = VarInt::from_u32(ack - 1);
-                            let size = range_count_size_increment(range_count)
-                                + gap.encoding_size()
-                                + ack.encoding_size();
-                            if capacity < size {
-                                // last_is_acked为false，不会被填进去
-                                return Break((0, 0, false));
-                            }
-                            capacity -= size;
-                            ranges.push((gap, ack));
-                            Continue((1, 0, state.track_packet_in_ack_frame(pn)))
-                        }
-                        // 如果当前是ack，增加ack，保持gap不变
-                        (false | true, true) => {
-                            Continue((gap, ack + 1, state.track_packet_in_ack_frame(pn)))
-                        }
-                        // 当前和之前都是gap，增加gap
-                        (false, false) => {
-                            Continue((gap + 1, ack, state.track_packet_in_ack_frame(pn)))
-                        }
-                    }
-                },
-            );
-        // 处理最后一个未来完成的range
-        if last_is_acked {
-            let gap = VarInt::from_u32(gap - 1);
-            let ack = VarInt::from_u32(ack - 1);
+        let mut ranges = Vec::new();
+        let mut current_start = range.start;
+        for previous in self.packets.ranges[..range_index].iter().rev() {
+            let gap = current_start
+                .checked_sub(previous.end + 1)
+                .ok_or(Signals::TRANSPORT)?;
+            let gap = VarInt::from_u64(gap).map_err(|_| Signals::TRANSPORT)?;
+            let ack = VarInt::from_u64(previous.end - previous.start - 1)
+                .map_err(|_| Signals::TRANSPORT)?;
             let size = range_count_size_increment(ranges.len())
                 + gap.encoding_size()
                 + ack.encoding_size();
-            if capacity > size {
-                // capacity -= size; unnecessary, never read latter
-                ranges.push((gap, ack));
+            if capacity < size {
+                break;
             }
+            capacity -= size;
+            ranges.push((gap, ack));
+            current_start = previous.start;
         }
-        self.packet_include_ack.insert(pn);
-        if let Some((pn, _)) = self.earliest_not_ack_time
-            && largest >= pn
-        {
-            self.earliest_not_ack_time = None;
-        }
+
         Ok(AckFrame::new(largest, delay, first_range, ranges, None))
     }
 
-    fn need_ack(&self) -> Option<(u64, Instant)> {
-        let now = tokio::time::Instant::now();
-        let (_, earliest_not_ack_time) = self.earliest_not_ack_time?;
-        let max_ack_delay = self.max_ack_delay.unwrap_or_default();
-        if earliest_not_ack_time + max_ack_delay >= now {
-            return None;
-        }
-        let (largest, state) = self.queue.back()?;
-        let recv_time = match state {
-            State::PacketReceived(rt, _, _)
-            | State::AckSent(_, rt, _, _)
-            | State::AckConfirmed(_, rt, _) => *rt,
-            _ => return None,
-        };
-
-        Some((largest, recv_time))
+    fn largest_received(&self) -> Option<(u64, Instant)> {
+        self.packets.largest()
     }
 }
 
-/// Records for received packets, decode the packet number and generate ack frames.
-// 接收数据包队列，各处共享的，判断包是否收到以及生成ack frame，只需要读锁；
-// 记录新收到的数据包，或者失活旧数据包并滑走，才需要写锁。
+/// Records for received packets, decodes packet numbers and generates ACK frames.
 #[derive(Debug, Clone, Default)]
 pub struct ArcRcvdJournal {
     inner: Arc<RwLock<RcvdJournal>>,
 }
 
 impl ArcRcvdJournal {
-    /// Create a new empty records with the given `capacity`.
-    ///
-    /// The number of records can exceed the `capacity` specified at creation time, but the internel
-    /// implementation strvies to avoid reallocation.
     pub fn with_capacity(capacity: usize, max_ack_delay: Option<Duration>) -> Self {
         Self {
             inner: Arc::new(RwLock::new(RcvdJournal::with_capacity(
@@ -295,31 +209,10 @@ impl ArcRcvdJournal {
         }
     }
 
-    /// Decode the pn from peer's packet to actual packer number.
-    ///
-    /// See [`RFC`](https://www.rfc-editor.org/rfc/rfc9000.html#name-sample-packet-number-decodi)
-    /// for more details about decode packet number.
-    ///
-    /// If the packet is too old or has been received, or the pn is too big, this method will return
-    /// an error.
-    ///
-    /// Note that although the packet number successful decoded, it does not mean that the packet is
-    /// valid, and the frames in it are valid.
-    ///
-    /// The registered packet must be valid, successfully decrypted, and the frames in it must be
-    /// valid.
-    // 当新收到一个数据包，如果这个包很旧，那么大概率意味着是重复包，直接丢弃。
-    // 如果这个数据包号是最大的，那么它之前的空档都是尚未收到的，得记为未收到。
-    // 注意，包号合法，不代表的包内容合法，必须等到包被正确解密且其中帧被正确解出后，才能确认收到。
     pub fn decode_pn(&self, encoded_pn: PacketNumber) -> Result<u64, InvalidPacketNumber> {
-        self.inner.write().unwrap().decode_pn(encoded_pn)
+        self.inner.read().unwrap().decode_pn(encoded_pn)
     }
 
-    /// Register the packet has been recieved.
-    ///
-    /// The registered packet must be valid, successfully decrypted, and the frames in it must be
-    /// valid.
-    // 当包号合法，且包被完全解密，且包中的帧都正确之后，记录该包已经收到。
     pub fn on_rcvd_pn(&self, pn: u64, is_ack_eliciting: bool, pto: Duration) {
         self.inner
             .write()
@@ -327,34 +220,20 @@ impl ArcRcvdJournal {
             .on_rcvd_pn(pn, is_ack_eliciting, pto);
     }
 
-    /// Generate an ack frame which ack the received frames until `largest`.
-    ///
-    /// This method will write an ack frame into the `buf`. The `Ack Delay` field of the frame is
-    /// the argument `recv_time` as microsec, the `Largest Acknowledged` field of the frame is the
-    /// `largest` frame, the ranges in ack frame will not exceed `largest`.
     pub fn gen_ack_frame_util(
         &self,
-        pn: u64,
         largest: u64,
         rcvd_time: Instant,
         capacity: usize,
     ) -> Result<AckFrame, Signals> {
         self.inner
-            .write()
+            .read()
             .unwrap()
-            .gen_ack_frame_util(pn, largest, rcvd_time, capacity)
+            .gen_ack_frame_util(largest, rcvd_time, capacity)
     }
 
-    pub fn on_rcvd_ack(&self, ack_frame: &AckFrame) {
-        self.inner.write().unwrap().on_rcvd_ack(ack_frame);
-    }
-
-    pub fn need_ack(&self) -> Option<(u64, Instant)> {
-        self.inner.read().unwrap().need_ack()
-    }
-
-    pub fn revise_max_ack_delay(&self, max_ack_delay: Duration) {
-        self.inner.write().unwrap().max_ack_delay = Some(max_ack_delay);
+    pub fn largest_received(&self) -> Option<(u64, Instant)> {
+        self.inner.read().unwrap().largest_received()
     }
 
     pub fn ack_package<'r>(&'r self, need_ack: Option<(u64, Instant)>) -> AckPackege<'r> {
@@ -376,19 +255,15 @@ where
     AckFrame: Package<Target>,
 {
     fn dump(&mut self, target: &mut Target) -> Result<PacketContent, Signals> {
-        self.need_ack
-            .or_else(|| self.journal.need_ack())
-            .ok_or(Signals::TRANSPORT)
-            .and_then(|(largest_ack, rcvd_time)| {
-                self.journal.gen_ack_frame_util(
-                    target.as_ref().packet_number(),
-                    largest_ack,
-                    rcvd_time,
-                    target.as_ref().remaining_mut(),
-                )
-            })?
-            .dump(target)
-            .unwrap();
+        // A path-local CC can request an ACK for a packet received on that path. The ACK frame is
+        // connection/epoch scoped, so always encode the shared journal's current largest packet.
+        let snapshot = self
+            .need_ack
+            .and_then(|_| self.journal.largest_received())
+            .ok_or(Signals::TRANSPORT)?;
+        self.journal
+            .gen_ack_frame_util(snapshot.0, snapshot.1, target.as_ref().remaining_mut())?
+            .dump(target)?;
         Ok(PacketContent::NonAckEliciting)
     }
 }
@@ -398,90 +273,95 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rcvd_pkt_records() {
+    fn contiguous_packets_merge_into_one_range() {
         let records = ArcRcvdJournal::with_capacity(16, None);
-        assert_eq!(records.decode_pn(PacketNumber::encode(1, 0)), Ok(1));
-        assert_eq!(records.inner.read().unwrap().queue.len(), 0);
-
-        let pto = Duration::from_millis(100);
-        records.on_rcvd_pn(1, true, pto);
-
-        assert_eq!(records.inner.read().unwrap().queue.len(), 2);
-        assert_eq!(
-            records.inner.read().unwrap().queue.get(0).unwrap(),
-            &State::Empty
-        );
-
-        assert!(matches!(
-            records.inner.read().unwrap().queue.get(1).unwrap(),
-            State::PacketReceived(_, _, _)
-        ));
-
-        let ack_frame = records.gen_ack_frame_util(0, 1, Instant::now(), 1200);
-
-        assert_eq!(&ack_frame.unwrap().largest(), &1);
-        assert!(
-            records
-                .inner
-                .read()
-                .unwrap()
-                .packet_include_ack
-                .contains(&0)
-        );
-
-        assert!(matches!(
-            records.inner.read().unwrap().queue.get(1).unwrap(),
-            State::AckSent(true, _, _, _)
-        ));
-
-        let ack_frame = AckFrame::new(0_u32.into(), 100_u32.into(), 0_u32.into(), vec![], None);
-
-        records.on_rcvd_ack(&ack_frame);
-
-        assert_eq!(records.inner.read().unwrap().queue.len(), 1);
-        let binding = records.inner.read().unwrap();
-        let record = binding.queue.get(1).unwrap();
-        assert!(matches!(record, State::AckConfirmed(_, _, _)));
+        for pn in [10, 12, 11] {
+            records.on_rcvd_pn(pn, true, Duration::ZERO);
+        }
+        let journal = records.inner.read().unwrap();
+        assert_eq!(journal.packets.ranges, vec![10..13]);
+        assert_eq!(journal.packets.ranges.len(), 1);
     }
 
     #[test]
-    fn gen_ack_frame() {
-        let rcvd_state = State::PacketReceived(Instant::now(), None, Instant::now());
-        let unrcvd_state = State::Empty;
-        let mut queue = IndexDeque::with_capacity(45);
-        for idx in 1..11 {
-            queue.insert(idx, rcvd_state.clone()).unwrap();
-        }
-        for idx in 11..12 {
-            queue.insert(idx, unrcvd_state.clone()).unwrap();
-        }
-        for idx in 12..45 {
-            queue.insert(idx, rcvd_state.clone()).unwrap();
-        }
-        for idx in 45..50 {
-            queue.insert(idx, unrcvd_state.clone()).unwrap();
-        }
-        for idx in 50..55 {
-            queue.insert(idx, rcvd_state.clone()).unwrap();
-        }
+    fn large_packet_number_gap_does_not_allocate_empty_states() {
+        let records = ArcRcvdJournal::with_capacity(16, None);
+        records.on_rcvd_pn(10, true, Duration::ZERO);
+        records.on_rcvd_pn(10_000_000, true, Duration::ZERO);
+        let journal = records.inner.read().unwrap();
+        assert_eq!(journal.packets.ranges, vec![10..11, 10_000_000..10_000_001]);
+    }
 
-        let mut rcvd_jornal = RcvdJournal {
-            queue,
-            max_ack_delay: None,
-            packet_include_ack: Default::default(),
-            earliest_not_ack_time: None,
-        };
+    #[test]
+    fn range_bound_evicts_oldest_and_retires_it() {
+        let records = ArcRcvdJournal::with_capacity(MAX_TRACKED_ACK_RANGES, None);
+        for pn in (0..=MAX_TRACKED_ACK_RANGES as u64 * 2).step_by(2) {
+            records.on_rcvd_pn(pn, true, Duration::ZERO);
+        }
+        let journal = records.inner.read().unwrap();
+        assert_eq!(journal.packets.ranges.len(), MAX_TRACKED_ACK_RANGES);
+        assert!(journal.packets.retired_before > 0);
+        drop(journal);
+        assert_eq!(
+            records.decode_pn(PacketNumber::encode(0, 0)),
+            Err(InvalidPacketNumber::TooOld)
+        );
+    }
 
-        let ack = rcvd_jornal
-            .gen_ack_frame_util(0, 52, Instant::now(), 1000)
+    #[test]
+    fn ack_ranges_preserve_holes_and_encode_exactly() {
+        let records = ArcRcvdJournal::with_capacity(16, None);
+        for pn in [100, 101, 104, 105, 110] {
+            records.on_rcvd_pn(pn, true, Duration::ZERO);
+        }
+        let ack = records
+            .gen_ack_frame_util(110, Instant::now(), 1200)
             .unwrap();
+        assert_eq!(ack.largest(), 110);
+        assert_eq!(ack.first_range(), 0);
         assert_eq!(
             ack.ranges(),
             &vec![
-                (VarInt::from_u32(50 - 45 - 1), VarInt::from_u32(45 - 12 - 1)),
-                (VarInt::from_u32(12 - 11 - 1), VarInt::from_u32(11 - 1 - 1))
+                (VarInt::from_u64(3).unwrap(), VarInt::from_u64(1).unwrap()),
+                (VarInt::from_u64(1).unwrap(), VarInt::from_u64(1).unwrap()),
             ]
         );
-        assert_eq!(ack.first_range(), 2)
+        assert!(ack.iter().any(|range| range == (100..=101)));
+        assert!(ack.iter().any(|range| range == (104..=105)));
+    }
+
+    #[test]
+    fn ack_generation_is_read_only() {
+        let records = ArcRcvdJournal::with_capacity(16, None);
+        records.on_rcvd_pn(1, true, Duration::ZERO);
+        let before = records.inner.read().unwrap().clone_for_test();
+        assert!(records.gen_ack_frame_util(1, Instant::now(), 1200).is_ok());
+        assert_eq!(records.inner.read().unwrap().clone_for_test(), before);
+    }
+
+    #[test]
+    fn high_packet_number_does_not_retire_slow_path_range() {
+        let records = ArcRcvdJournal::with_capacity(16, None);
+        records.on_rcvd_pn(100, true, Duration::ZERO);
+        records.on_rcvd_pn(10_000, true, Duration::ZERO);
+        assert_eq!(
+            records.inner.read().unwrap().packets.ranges,
+            vec![100..101, 10_000..10_001]
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct JournalSnapshot {
+        ranges: Vec<Range<u64>>,
+        retired_before: u64,
+    }
+
+    impl RcvdJournal {
+        fn clone_for_test(&self) -> JournalSnapshot {
+            JournalSnapshot {
+                ranges: self.packets.ranges.clone(),
+                retired_before: self.packets.retired_before,
+            }
+        }
     }
 }

--- a/qrecovery/src/journal/rcvd.rs
+++ b/qrecovery/src/journal/rcvd.rs
@@ -133,10 +133,17 @@ impl RcvdJournal {
         rcvd_time: Instant,
         mut capacity: usize,
     ) -> Result<AckFrame, Signals> {
-        let Some(range_index) = self.packets.range_containing(largest) else {
-            return Err(Signals::TRANSPORT);
+        let (range_start, previous_ranges) = match self.packets.range_containing(largest) {
+            Some(range_index) => (
+                self.packets.ranges[range_index].start,
+                &self.packets.ranges[..range_index],
+            ),
+            // A path-local ACK trigger is independent of the bounded shared journal. If its range
+            // has since been retired, the trigger still proves that this packet was received, so a
+            // singleton ACK is valid and lets that path finish its pending ACK cycle.
+            None if largest < self.packets.retired_before => (largest, &[][..]),
+            None => return Err(Signals::TRANSPORT),
         };
-        let range = &self.packets.ranges[range_index];
         let largest = VarInt::from_u64(largest).map_err(|_| Signals::TRANSPORT)?;
         let delay: u64 = rcvd_time
             .elapsed()
@@ -146,7 +153,7 @@ impl RcvdJournal {
             .min(VARINT_MAX);
         let delay = VarInt::from_u64(delay).map_err(|_| Signals::TRANSPORT)?;
         let first_range =
-            VarInt::from_u64(largest.into_u64() - range.start).map_err(|_| Signals::TRANSPORT)?;
+            VarInt::from_u64(largest.into_u64() - range_start).map_err(|_| Signals::TRANSPORT)?;
 
         // Frame type + Largest Acknowledged + ACK Delay + ACK Range Count + First ACK Range.
         let min_len =
@@ -166,8 +173,8 @@ impl RcvdJournal {
         }
 
         let mut ranges = Vec::new();
-        let mut current_start = range.start;
-        for previous in self.packets.ranges[..range_index].iter().rev() {
+        let mut current_start = range_start;
+        for previous in previous_ranges.iter().rev() {
             let gap = current_start
                 .checked_sub(previous.end + 1)
                 .ok_or(Signals::TRANSPORT)?;
@@ -186,10 +193,6 @@ impl RcvdJournal {
         }
 
         Ok(AckFrame::new(largest, delay, first_range, ranges, None))
-    }
-
-    fn largest_received(&self) -> Option<(u64, Instant)> {
-        self.packets.largest()
     }
 }
 
@@ -232,10 +235,6 @@ impl ArcRcvdJournal {
             .gen_ack_frame_util(largest, rcvd_time, capacity)
     }
 
-    pub fn largest_received(&self) -> Option<(u64, Instant)> {
-        self.inner.read().unwrap().largest_received()
-    }
-
     pub fn ack_package<'r>(&'r self, need_ack: Option<(u64, Instant)>) -> AckPackege<'r> {
         AckPackege {
             journal: self,
@@ -249,20 +248,24 @@ pub struct AckPackege<'r> {
     need_ack: Option<(u64, Instant)>,
 }
 
+impl AckPackege<'_> {
+    fn gen_ack_frame(&self, capacity: usize) -> Result<AckFrame, Signals> {
+        let (largest, rcvd_time) = self.need_ack.ok_or(Signals::TRANSPORT)?;
+        self.journal
+            .gen_ack_frame_util(largest, rcvd_time, capacity)
+    }
+}
+
 impl<'r, Target> Package<Target> for AckPackege<'r>
 where
     Target: AsRef<PacketWriter<'r>> + ?Sized,
     AckFrame: Package<Target>,
 {
     fn dump(&mut self, target: &mut Target) -> Result<PacketContent, Signals> {
-        // A path-local CC can request an ACK for a packet received on that path. The ACK frame is
-        // connection/epoch scoped, so always encode the shared journal's current largest packet.
-        let snapshot = self
-            .need_ack
-            .and_then(|_| self.journal.largest_received())
-            .ok_or(Signals::TRANSPORT)?;
-        self.journal
-            .gen_ack_frame_util(snapshot.0, snapshot.1, target.as_ref().remaining_mut())?
+        // Packet numbers and ACK ranges are connection/epoch scoped, but ACK scheduling is
+        // path-local. Start at this path's trigger so a high PN received on another path cannot
+        // consume this ACK cycle while leaving the trigger outside a capacity-limited frame.
+        self.gen_ack_frame(target.as_ref().remaining_mut())?
             .dump(target)?;
         Ok(PacketContent::NonAckEliciting)
     }
@@ -348,6 +351,41 @@ mod tests {
             records.inner.read().unwrap().packets.ranges,
             vec![100..101, 10_000..10_001]
         );
+    }
+
+    #[test]
+    fn path_local_trigger_selects_ack_largest_in_shared_journal() {
+        let records = ArcRcvdJournal::with_capacity(16, None);
+        records.on_rcvd_pn(100, true, Duration::ZERO);
+        records.on_rcvd_pn(10_000, true, Duration::ZERO);
+
+        let ack = records
+            .ack_package(Some((100, Instant::now())))
+            .gen_ack_frame(1200)
+            .unwrap();
+
+        assert_eq!(ack.largest(), 100);
+        assert!(ack.iter().any(|range| range.contains(&100)));
+        assert!(!ack.iter().any(|range| range.contains(&10_000)));
+    }
+
+    #[test]
+    fn retired_path_trigger_can_still_generate_singleton_ack() {
+        let records = ArcRcvdJournal::with_capacity(MAX_TRACKED_ACK_RANGES, None);
+        records.on_rcvd_pn(0, true, Duration::ZERO);
+        for pn in (2..=MAX_TRACKED_ACK_RANGES as u64 * 2).step_by(2) {
+            records.on_rcvd_pn(pn, true, Duration::ZERO);
+        }
+        assert!(!records.inner.read().unwrap().packets.contains(0));
+
+        let ack = records
+            .ack_package(Some((0, Instant::now())))
+            .gen_ack_frame(1200)
+            .unwrap();
+
+        assert_eq!(ack.largest(), 0);
+        assert_eq!(ack.first_range(), 0);
+        assert_eq!(ack.ranges(), &[]);
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/qrecovery/src/journal/sent.rs
+++ b/qrecovery/src/journal/sent.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque,
+    ops::RangeInclusive,
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
@@ -150,6 +151,40 @@ struct SentJournal<T> {
 }
 
 impl<T: Clone> SentJournal<T> {
+    fn acked_record_numbers(&self, ack_frame: &AckFrame) -> Vec<u64> {
+        let ack_ranges = ack_frame.iter_ranges().collect::<Vec<_>>();
+        self.sent_packets
+            .iter()
+            .rev()
+            .filter(|record| {
+                ack_ranges
+                    .iter()
+                    .any(|range| range.contains(&record.packet_number))
+            })
+            .map(|record| record.packet_number)
+            .collect()
+    }
+
+    fn on_packets_acked(&mut self, ack_frame: &AckFrame) -> std::vec::IntoIter<T> {
+        let ack_ranges = ack_frame
+            .iter_ranges()
+            .collect::<Vec<RangeInclusive<u64>>>();
+        let mut offset = self.queue.len();
+        let mut frames = Vec::new();
+        for record in self.sent_packets.iter_mut().rev() {
+            let nframes = record.state.nframes();
+            offset -= nframes;
+            if ack_ranges
+                .iter()
+                .any(|range| range.contains(&record.packet_number))
+            {
+                let len = record.state.be_acked();
+                frames.extend(self.queue.range(offset..offset + len).cloned());
+            }
+        }
+        frames.into_iter()
+    }
+
     fn record_index_and_offset(&self, pn: u64) -> Option<(usize, usize)> {
         let mut offset = 0;
         for (index, record) in self.sent_packets.iter().enumerate() {
@@ -273,6 +308,14 @@ pub struct SentRotateGuard<'a, T> {
 }
 
 impl<T: Clone> SentRotateGuard<'_, T> {
+    pub fn acked_packet_numbers(&self, ack_frame: &AckFrame) -> Vec<u64> {
+        self.inner.acked_record_numbers(ack_frame)
+    }
+
+    pub fn on_packets_acked(&mut self, ack_frame: &AckFrame) -> impl Iterator<Item = T> + '_ {
+        self.inner.on_packets_acked(ack_frame)
+    }
+
     pub fn update_largest(&mut self, ack_frame: &AckFrame) -> Result<(), QuicError> {
         if ack_frame.largest() >= self.inner.next_pn {
             return Err(QuicError::new(
@@ -438,8 +481,13 @@ mod tests {
         }
 
         let mut rotate = journal.rotate();
-        rotate.update_largest(&ack_packet(5)).unwrap();
-        assert_eq!(rotate.on_packet_acked(5).collect::<Vec<_>>(), vec![5]);
+        let ack = AckFrame::new(5_u32.into(), 0_u32.into(), 5_u32.into(), vec![], None);
+        rotate.update_largest(&ack).unwrap();
+        assert_eq!(rotate.acked_packet_numbers(&ack), vec![5, 1]);
+        assert_eq!(
+            rotate.on_packets_acked(&ack).collect::<Vec<_>>(),
+            vec![5, 1]
+        );
         assert!(rotate.on_packet_acked(4).next().is_none());
     }
 

--- a/qrecovery/src/journal/sent.rs
+++ b/qrecovery/src/journal/sent.rs
@@ -1,27 +1,20 @@
 use std::{
     collections::VecDeque,
-    ops::DerefMut,
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
 
-use derive_more::{Deref, DerefMut};
 use qbase::{
     error::{ErrorKind, QuicError},
     frame::{AckFrame, GetFrameType},
     packet::PacketNumber,
-    util::IndexDeque,
     varint::VARINT_MAX,
 };
 use tokio::time::Instant;
 
-/// 记录发送的数据包的状态，包括
-/// - Flighting: 数据包正在传输中
-/// - Acked: 数据包已经被确认
-/// - Lost: 数据包丢失
+/// State for a sent packet that contains frames requiring ACK/loss feedback.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SentPktState {
-    Skipped,
     Flighting {
         nframes: usize,
         sent_time: Instant,
@@ -41,11 +34,6 @@ enum SentPktState {
 }
 
 impl SentPktState {
-    #[allow(dead_code)]
-    fn skipped() -> Self {
-        Self::Skipped
-    }
-
     fn new(nframes: usize, sent_time: Instant, retran_time: Instant, expire_time: Instant) -> Self {
         Self::Flighting {
             nframes,
@@ -57,55 +45,45 @@ impl SentPktState {
 
     fn nframes(&self) -> usize {
         match self {
-            SentPktState::Skipped => 0,
-            SentPktState::Flighting { nframes, .. } => *nframes,
-            SentPktState::Retransmitted { nframes, .. } => *nframes,
-            SentPktState::Acked { nframes, .. } => *nframes,
+            Self::Flighting { nframes, .. }
+            | Self::Retransmitted { nframes, .. }
+            | Self::Acked { nframes, .. } => *nframes,
         }
     }
 
     fn be_acked(&mut self) -> usize {
         match *self {
-            SentPktState::Skipped => 0,
-            SentPktState::Flighting {
+            Self::Flighting {
                 nframes,
                 sent_time,
                 expire_time,
                 ..
+            }
+            | Self::Retransmitted {
+                nframes,
+                sent_time,
+                expire_time,
             } => {
-                *self = SentPktState::Acked {
+                *self = Self::Acked {
                     nframes,
                     sent_time,
                     expire_time,
                 };
                 nframes
             }
-            SentPktState::Retransmitted {
-                nframes,
-                sent_time,
-                expire_time,
-                ..
-            } => {
-                *self = SentPktState::Acked {
-                    nframes,
-                    sent_time,
-                    expire_time,
-                };
-                nframes
-            }
-            SentPktState::Acked { .. } => 0,
+            Self::Acked { .. } => 0,
         }
     }
 
     fn maybe_lost(&mut self) -> usize {
         match *self {
-            SentPktState::Flighting {
+            Self::Flighting {
                 nframes,
                 sent_time,
                 expire_time,
                 ..
             } => {
-                *self = SentPktState::Retransmitted {
+                *self = Self::Retransmitted {
                     nframes,
                     sent_time,
                     expire_time,
@@ -113,20 +91,20 @@ impl SentPktState {
                 nframes
             }
             Self::Retransmitted { nframes, .. } => nframes,
-            _ => 0,
+            Self::Acked { .. } => 0,
         }
     }
 
-    fn should_retransmit_after(&mut self, now: &Instant) -> bool {
+    fn should_retransmit_after(&mut self, now: Instant) -> bool {
         match *self {
-            SentPktState::Flighting {
+            Self::Flighting {
+                nframes,
                 sent_time,
                 retran_time,
                 expire_time,
-                ..
-            } if retran_time < *now => {
-                *self = SentPktState::Retransmitted {
-                    nframes: self.nframes(),
+            } if retran_time < now => {
+                *self = Self::Retransmitted {
+                    nframes,
                     sent_time,
                     expire_time,
                 };
@@ -136,86 +114,96 @@ impl SentPktState {
         }
     }
 
-    fn should_remain_after(&self, pn: u64, now: &Instant) -> bool {
+    fn should_remain_after(&self, pn: u64, now: Instant) -> bool {
         match self {
-            SentPktState::Skipped => false,
-            SentPktState::Flighting { .. } => true,
-            SentPktState::Retransmitted { expire_time, .. } => {
-                if expire_time > now {
+            Self::Flighting { .. } => true,
+            Self::Retransmitted { expire_time, .. } => {
+                if *expire_time > now {
                     true
                 } else {
-                    tracing::trace!(target: "dquic", "retransmitted packet {pn} is expired without ack");
+                    tracing::trace!(target: "dquic", "retransmitted packet {pn} expired without ACK");
                     false
                 }
             }
-            SentPktState::Acked { .. } => false,
+            Self::Acked { .. } => false,
         }
     }
 }
 
-/// 记录已经发送的帧，尽最大努力省略内存分配。
-/// queue记录着所有发送过的帧，records记录着顺序发送的数据包包含几个帧，以及这些数据包的状态。
-/// 发送数据包的时候，往其中写入数据包的帧，
-/// 接收到确认的时候，更新数据包的状态，被确认就什么都不做；丢失的数据包，得重新发送
-#[derive(Debug, Default, Deref, DerefMut)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SentPacketRecord {
+    packet_number: u64,
+    state: SentPktState,
+}
+
+/// Reliable-frame feedback journal for sent packets.
+///
+/// Packet numbers are allocated by `next_pn`, while `sent_packets` only stores packets containing
+/// reliable frames. Pure ACK/PING/PADDING packets consume packet numbers but allocate no journal
+/// record, so a long-lived earlier packet cannot pin a dense tail of `Skipped` entries.
+#[derive(Debug, Default)]
 struct SentJournal<T> {
-    #[deref]
-    #[deref_mut]
     queue: VecDeque<T>,
-    // 记录着每个包的内容，其实是一个数字，该数字对应着queue中的record数量
-    sent_packets: IndexDeque<SentPktState, VARINT_MAX>,
+    sent_packets: VecDeque<SentPacketRecord>,
+    next_pn: u64,
     largest_acked_pktno: u64,
 }
 
 impl<T: Clone> SentJournal<T> {
-    fn on_packet_acked(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
-        let mut len = 0;
-        let offset = self
-            .sent_packets
-            .enumerate()
-            .take_while(|(pkt_idx, _)| *pkt_idx < pn)
-            .map(|(_, s)| s.nframes())
-            .sum::<usize>();
-        if let Some(s) = self.sent_packets.get_mut(pn) {
-            len = s.be_acked();
+    fn record_index_and_offset(&self, pn: u64) -> Option<(usize, usize)> {
+        let mut offset = 0;
+        for (index, record) in self.sent_packets.iter().enumerate() {
+            if record.packet_number == pn {
+                return Some((index, offset));
+            }
+            if record.packet_number > pn {
+                break;
+            }
+            offset += record.state.nframes();
         }
-        self.queue
-            .range_mut(offset..offset + len)
-            .map(|f| f.clone())
+        None
+    }
+
+    fn on_packet_acked(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
+        let (offset, len) = self
+            .record_index_and_offset(pn)
+            .map(|(index, offset)| {
+                let len = self.sent_packets[index].state.be_acked();
+                (offset, len)
+            })
+            .unwrap_or_default();
+        self.queue.range(offset..offset + len).cloned()
     }
 
     fn may_loss_packet(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
-        let mut len = 0;
-        let offset = self
-            .sent_packets
-            .enumerate()
-            // TODO(optimize): 调用者是一种遍历，每次都从头take_while，可以优化
-            .take_while(|(pkt_idx, _)| *pkt_idx < pn)
-            .map(|(_, s)| s.nframes())
-            .sum::<usize>();
-        if let Some(s) = self.sent_packets.get_mut(pn) {
-            len = s.maybe_lost();
-        }
-        self.queue
-            .range_mut(offset..offset + len)
-            .map(|f| f.clone())
+        let (offset, len) = self
+            .record_index_and_offset(pn)
+            .map(|(index, offset)| {
+                let len = self.sent_packets[index].state.maybe_lost();
+                (offset, len)
+            })
+            .unwrap_or_default();
+        self.queue.range(offset..offset + len).cloned()
     }
 
-    fn fast_retransmit(&mut self) -> impl Iterator<Item = T> + '_ {
+    fn fast_retransmit(&mut self) -> std::vec::IntoIter<T> {
         self.resize();
-
-        let now = tokio::time::Instant::now();
-        self.sent_packets
-            .enumerate_mut()
-            .take_while(|(pn, _)| *pn < self.largest_acked_pktno)
-            .scan(0, move |sum, (_, s)| {
-                let start = *sum;
-                *sum += s.nframes();
-                Some((s.should_retransmit_after(&now), start..*sum))
-            })
-            .filter(|(should_retran, _)| *should_retran)
-            .flat_map(|(_, r)| self.queue.range(r))
-            .cloned()
+        let now = Instant::now();
+        let largest_acked = self.largest_acked_pktno;
+        let mut offset = 0;
+        let mut frames = Vec::new();
+        for record in self
+            .sent_packets
+            .iter_mut()
+            .take_while(|record| record.packet_number < largest_acked)
+        {
+            let end = offset + record.state.nframes();
+            if record.state.should_retransmit_after(now) {
+                frames.extend(self.queue.range(offset..end).cloned());
+            }
+            offset = end;
+        }
+        frames.into_iter()
     }
 }
 
@@ -223,40 +211,27 @@ impl<T> SentJournal<T> {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             queue: VecDeque::with_capacity(capacity * 4),
-            sent_packets: IndexDeque::with_capacity(capacity),
+            sent_packets: VecDeque::with_capacity(capacity),
+            next_pn: 0,
             largest_acked_pktno: 0,
         }
     }
 
     fn resize(&mut self) {
         let now = Instant::now();
-        let (n, f) = self
+        let (records, frames) = self
             .sent_packets
-            .enumerate()
-            .take_while(|(pn, s)| !s.should_remain_after(*pn, &now))
-            .fold((0usize, 0usize), |(n, f), (_, s)| (n + 1, f + s.nframes()));
-        self.sent_packets.advance(n);
-        _ = self.queue.drain(..f);
+            .iter()
+            .take_while(|record| !record.state.should_remain_after(record.packet_number, now))
+            .fold((0usize, 0usize), |(records, frames), record| {
+                (records + 1, frames + record.state.nframes())
+            });
+        self.sent_packets.drain(..records);
+        self.queue.drain(..frames);
     }
 }
 
-/// Records for sent packets and frames in them.
-///
-/// [`DataStreams`] need to be aware of frame acknowledgment or possible loss, and so does [`CryptoStream`].
-/// This structure records some frames (type T) in each packet sent, and feeds back the frames in
-/// these packets to [`DataStreams`] and [`CryptoStream`] when the packet is acknowledged or may be
-/// lost.
-///
-/// The interfaces are on the [`NewPacketGuard`] structure and the [`SentRotateGuard`] structure, read their
-/// documentation for more. This structure only provide the methods to create them.
-///
-/// If multiple tasks are recording at the same time, the recording will become confusing, so the
-/// [`NewPacketGuard`] and the [`SentRotateGuard`] are designed to be `Guard`, which means that they hold a
-/// [`MutexGuard`].
-///
-///
-/// [`DataStreams`]: crate::streams::DataStreams
-/// [`CryptoStream`]: crate::crypto::CryptoStream
+/// Records sent packets and the reliable frames they contain.
 #[derive(Debug, Default)]
 pub struct ArcSentJournal<T>(Arc<Mutex<SentJournal<T>>>);
 
@@ -267,62 +242,53 @@ impl<T> Clone for ArcSentJournal<T> {
 }
 
 impl<T> ArcSentJournal<T> {
-    /// Create a new empty records with the given `capatity`.
-    ///
-    /// The number of records can exceed the `capacity` specified at creation time, but the internel
-    /// implementation strvies to avoid reallocation.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Arc::new(Mutex::new(SentJournal::with_capacity(capacity))))
     }
 
-    /// Return a [`SentRotateGuard`] to resolve the ack frame from peer.
     pub fn rotate(&self) -> SentRotateGuard<'_, T> {
         SentRotateGuard {
             inner: self.0.lock().unwrap(),
         }
     }
 
-    /// Return a [`NewPacketGuard`] to get the next pn and record frames in the packet.
     pub fn new_packet(&self) -> NewPacketGuard<'_, T> {
         let inner = self.0.lock().unwrap();
+        assert!(inner.next_pn <= VARINT_MAX, "packet number exhausted");
+        let packet_number = inner.next_pn;
         let origin_len = inner.queue.len();
         NewPacketGuard {
             trivial: false,
+            committed: false,
+            packet_number,
             origin_len,
             inner,
         }
     }
 }
 
-/// Handle the peer's ack frame and feed back the frames in the acknowledged or possibly lost packets to other components.
+/// Handles peer ACK/loss feedback for retained reliable packets.
 pub struct SentRotateGuard<'a, T> {
     inner: MutexGuard<'a, SentJournal<T>>,
 }
 
 impl<T: Clone> SentRotateGuard<'_, T> {
-    /// Handle the [`Largest Acknowledged`] field of the ack frame from peer.
-    ///
-    /// [`Largest Acknowleged`]: https://www.rfc-editor.org/rfc/rfc9000.html#name-ack-frames
     pub fn update_largest(&mut self, ack_frame: &AckFrame) -> Result<(), QuicError> {
-        if ack_frame.largest() > self.inner.sent_packets.largest() {
+        if ack_frame.largest() >= self.inner.next_pn {
             return Err(QuicError::new(
                 ErrorKind::ProtocolViolation,
                 ack_frame.frame_type().into(),
-                "ack frame largest pn is larger than the largest pn sent",
+                "ACK frame largest PN is not smaller than the next PN to send",
             ));
         }
-        if ack_frame.largest() > self.inner.largest_acked_pktno {
-            self.inner.largest_acked_pktno = ack_frame.largest();
-        }
+        self.inner.largest_acked_pktno = self.inner.largest_acked_pktno.max(ack_frame.largest());
         Ok(())
     }
 
-    /// Called when the packet sent is acked by peer, return the frames in that packet.
     pub fn on_packet_acked(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
         self.inner.on_packet_acked(pn)
     }
 
-    /// Called when the packet sent may lost, reutrn the frames in that packet.
     pub fn may_loss_packet(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
         self.inner.may_loss_packet(pn)
     }
@@ -338,82 +304,152 @@ impl<T> Drop for SentRotateGuard<'_, T> {
     }
 }
 
-/// Provide the [encoded] packet number to assemble a packet, and record the frames in packet which
-/// will be send.
+/// Reserves a packet number and records frames while a packet is assembled.
 ///
-/// One [`NewPacketGuard`] correspond to a packet.
-///
-/// Even if the next packet number is obtained, the packet may not be sent out. If the packet is not
-/// sent out, the packet number will not be consumed.
-///
-/// Call [`NewPacketGuard::record_trivial`] or [`NewPacketGuard::record_frame`] means that the packet will be
-/// correspond to this [`NewPacketGuard`] will be sent, and the packet number will be consumed when the
-/// [`NewPacketGuard`] dropped.
-///
-/// [encoded]: https://www.rfc-editor.org/rfc/rfc9000.html#name-sample-packet-number-encodi
+/// Dropping this guard before either build method rolls back tentative frames and leaves the packet
+/// number available for reuse. A successful build consumes the PN but stores a record only when the
+/// packet contains reliable frames.
 #[derive(Debug)]
 pub struct NewPacketGuard<'a, T> {
     trivial: bool,
+    committed: bool,
+    packet_number: u64,
     origin_len: usize,
     inner: MutexGuard<'a, SentJournal<T>>,
 }
 
 impl<T> NewPacketGuard<'_, T> {
-    /// Provide a packet number and its [encoded] form to assemble a packet.
-    ///
-    /// Call this method multipes on the same [`NewPacketGuard`] will result the same pn.
-    ///
-    /// [encoded]: https://www.rfc-editor.org/rfc/rfc9000.html#name-sample-packet-number-encodi
     pub fn pn(&self) -> (u64, PacketNumber) {
-        let pn = self.inner.sent_packets.largest();
-        let encoded_pn = PacketNumber::encode(pn, self.inner.largest_acked_pktno);
-        (pn, encoded_pn)
+        let encoded_pn = PacketNumber::encode(self.packet_number, self.inner.largest_acked_pktno);
+        (self.packet_number, encoded_pn)
     }
 
-    /// Records trivial frames that do not need retransmission, such as Padding, Ping, and Ack.
-    /// However, this packet does occupy a packet number. Even if no other reliable frames are sent,
-    /// it still needs to be recorded, with the number of reliable frames in this packet being 0.
     pub fn record_trivial(&mut self) {
         self.trivial = true;
     }
 
-    /// Records a frame in the packet being sent.
-    ///
-    /// Once this method or [`NewPacketGuard::record_trivial`] called, the packet number will be consumed.
-    ///
-    /// When the packet is acked, or may loss, the frames in packet will been fed back to the
-    /// components which sent them.
     pub fn record_frame(&mut self, frame: T) {
-        self.inner.deref_mut().push_back(frame);
+        self.inner.queue.push_back(frame);
+    }
+
+    fn commit(&mut self) {
+        debug_assert_eq!(self.inner.next_pn, self.packet_number);
+        self.inner.next_pn = self
+            .inner
+            .next_pn
+            .checked_add(1)
+            .expect("packet number never overflows u64");
+        self.committed = true;
     }
 
     pub fn build_with_time(mut self, retran_timeout: Duration, expire_timeout: Duration) {
         let nframes = self.inner.queue.len() - self.origin_len;
-        let sent_time = tokio::time::Instant::now();
-        if self.trivial && nframes == 0 {
-            self.inner
-                .sent_packets
-                .push_back(SentPktState::Skipped)
-                .expect("packet number never overflow");
-        } else if nframes > 0 {
-            self.inner
-                .sent_packets
-                .push_back(SentPktState::new(
+        assert!(self.trivial || nframes > 0, "cannot commit an empty packet");
+        if nframes > 0 {
+            let sent_time = Instant::now();
+            self.inner.sent_packets.push_back(SentPacketRecord {
+                packet_number: self.packet_number,
+                state: SentPktState::new(
                     nframes,
                     sent_time,
                     sent_time + retran_timeout,
                     sent_time + expire_timeout,
-                ))
-                .expect("packet number never overflow");
+                ),
+            });
         }
+        self.commit();
     }
 
     pub fn build_trivial(mut self) {
         assert_eq!(self.inner.queue.len(), self.origin_len);
         assert!(self.trivial);
-        self.inner
-            .sent_packets
-            .push_back(SentPktState::Skipped)
-            .expect("packet number never overflow");
+        self.commit();
+    }
+}
+
+impl<T> Drop for NewPacketGuard<'_, T> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.inner.queue.truncate(self.origin_len);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use qbase::{frame::AckFrame, varint::VarInt};
+
+    use super::*;
+
+    fn ack_packet(pn: u64) -> AckFrame {
+        AckFrame::new(
+            VarInt::from_u64(pn).unwrap(),
+            0_u32.into(),
+            0_u32.into(),
+            vec![],
+            None,
+        )
+    }
+
+    #[test]
+    fn trivial_packets_only_advance_next_packet_number() {
+        let journal = ArcSentJournal::<u64>::with_capacity(1);
+        for expected in 0..100_000 {
+            let mut packet = journal.new_packet();
+            assert_eq!(packet.pn().0, expected);
+            packet.record_trivial();
+            packet.build_trivial();
+        }
+        let inner = journal.0.lock().unwrap();
+        assert_eq!(inner.next_pn, 100_000);
+        assert!(inner.sent_packets.is_empty());
+        assert!(inner.queue.is_empty());
+    }
+
+    #[test]
+    fn dropped_packet_rolls_back_frames_and_packet_number() {
+        let journal = ArcSentJournal::<u64>::with_capacity(1);
+        {
+            let mut packet = journal.new_packet();
+            assert_eq!(packet.pn().0, 0);
+            packet.record_frame(7);
+        }
+        let packet = journal.new_packet();
+        assert_eq!(packet.pn().0, 0);
+        drop(packet);
+        let inner = journal.0.lock().unwrap();
+        assert_eq!(inner.next_pn, 0);
+        assert!(inner.sent_packets.is_empty());
+        assert!(inner.queue.is_empty());
+    }
+
+    #[test]
+    fn sparse_reliable_packets_keep_exact_packet_numbers() {
+        let journal = ArcSentJournal::<u64>::with_capacity(4);
+        for pn in 0..6 {
+            let mut packet = journal.new_packet();
+            if pn == 1 || pn == 5 {
+                packet.record_frame(pn);
+                packet.build_with_time(Duration::from_secs(1), Duration::from_secs(2));
+            } else {
+                packet.record_trivial();
+                packet.build_trivial();
+            }
+        }
+
+        let mut rotate = journal.rotate();
+        rotate.update_largest(&ack_packet(5)).unwrap();
+        assert_eq!(rotate.on_packet_acked(5).collect::<Vec<_>>(), vec![5]);
+        assert!(rotate.on_packet_acked(4).next().is_none());
+    }
+
+    #[test]
+    fn ack_for_unsent_packet_is_rejected() {
+        let journal = ArcSentJournal::<u64>::with_capacity(1);
+        let mut packet = journal.new_packet();
+        packet.record_trivial();
+        packet.build_trivial();
+        assert!(journal.rotate().update_largest(&ack_packet(1)).is_err());
+        assert!(journal.rotate().update_largest(&ack_packet(0)).is_ok());
     }
 }

--- a/qresolve/Cargo.toml
+++ b/qresolve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qresolve"
-version = "0.8.0"
+version = "0.8.0-beta.1"
 edition.workspace = true
 description = "dquic's dns abstractions"
 readme.workspace = true

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.0"
+version = "0.7.1-beta.1"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qtraversal/examples/stun_client.rs
+++ b/qtraversal/examples/stun_client.rs
@@ -1,10 +1,7 @@
 use std::{io::Result, net::SocketAddr, sync::Arc};
 
 use clap::Parser;
-use qinterface::{
-    component::local_endpoint::LocalEndpoints,
-    io::{IO, ProductIO, handy::DEFAULT_IO_FACTORY},
-};
+use qinterface::io::{IO, ProductIO, handy::DEFAULT_IO_FACTORY};
 use qtraversal::{
     nat::{client::StunClient, router::StunRouter},
     route::ReceiveAndDeliverPacket,
@@ -15,7 +12,7 @@ use tracing::info;
 pub struct Arguments {
     #[arg(long, default_value = "0.0.0.0:12345")]
     pub bind: SocketAddr,
-    #[arg(long, default_value = "nat.genmeta.net:20004")]
+    #[arg(long, default_value = "nat.genmeta.net:20002")]
     pub stun_svr: String,
 }
 
@@ -45,17 +42,9 @@ async fn main() -> Result<()> {
         .await
         .expect("failed to get outer addr");
     info!(target: "stun", %outer_addr, agent_addr = %stun_server, "detected outer address");
-    // Ok(())
     let nat_type = stun_client.nat_type().await;
-    let local_endpoints = std::sync::Arc::new(LocalEndpoints::new());
-    let mut subscriber = local_endpoints.subscribe();
-    while let Some(event) = subscriber.recv().await {
-        info!(target: "stun", ?event, "local endpoint event");
-        info!(target: "stun", ?nat_type, "detected NAT type");
-    }
+    info!(target: "stun", ?nat_type, "detected NAT type");
     Ok(())
-
-    // unreachable!("Observer never return None")
 }
 
 fn init_logger() -> std::io::Result<()> {

--- a/qtraversal/examples/stun_server.rs
+++ b/qtraversal/examples/stun_server.rs
@@ -9,26 +9,32 @@ use qtraversal::{
     },
     route::{Forwarder, ReceiveAndDeliverPacket},
 };
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Arguments {
     #[arg(long, default_value = "127.0.0.1:20002")]
     pub bind_addr1: SocketAddr,
-    #[arg(long, default_value = "127.0.0.1:4433")]
+    #[arg(long, default_value = "127.0.0.1:20003")]
     pub bind_addr2: SocketAddr,
-    #[arg(long, default_value = "127.0.0.1:20002")]
-    pub change_addr: SocketAddr,
-    #[arg(long, default_value = "127.0.0.1:20002")]
+    /// Public alternate listener on another node for requests received on bind-addr1.
+    #[arg(long)]
+    pub change_addr1: SocketAddr,
+    /// Public primary listener on another node for requests received on bind-addr2.
+    #[arg(long)]
+    pub change_addr2: SocketAddr,
+    /// Public address corresponding to bind-addr1.
+    #[arg(long)]
     pub outer_addr1: SocketAddr,
-    #[arg(long, default_value = "127.0.0.1:20002")]
+    /// Public address corresponding to bind-addr2.
+    #[arg(long)]
     pub outer_addr2: SocketAddr,
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let args = Arguments::parse();
-    init_logger(&args)?;
+    validate_args(&args)?;
+    init_logger();
 
     let factory: Arc<dyn ProductIO> = Arc::new(DEFAULT_IO_FACTORY);
 
@@ -59,7 +65,8 @@ async fn main() -> Result<()> {
         stun_router1,
         StunServerConfig::builder()
             .change_port(args.bind_addr2.port())
-            .change_address(args.change_addr)
+            .change_address(args.change_addr1)
+            .outer_address(args.outer_addr1)
             .init(),
     );
     let server2 = StunServer::new(
@@ -67,28 +74,120 @@ async fn main() -> Result<()> {
         stun_router2,
         StunServerConfig::builder()
             .change_port(args.bind_addr1.port())
-            .change_address(args.change_addr)
+            .change_address(args.change_addr2)
+            .outer_address(args.outer_addr2)
             .init(),
     );
     _ = tokio::try_join!(server1.spawn(), server2.spawn())?;
     Ok(())
 }
 
-fn init_logger(args: &Arguments) -> std::io::Result<()> {
-    let log_name = args.bind_addr1.ip().to_string() + "-stun.log";
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(log_name)?;
+fn validate_args(args: &Arguments) -> Result<()> {
+    let addresses = [
+        args.bind_addr1,
+        args.bind_addr2,
+        args.change_addr1,
+        args.change_addr2,
+        args.outer_addr1,
+        args.outer_addr2,
+    ];
+    if addresses
+        .iter()
+        .any(|addr| addr.is_ipv4() != args.bind_addr1.is_ipv4())
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "all STUN addresses must use the same address family",
+        ));
+    }
+    if args.bind_addr1.ip() != args.bind_addr2.ip() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "bind-addr1 and bind-addr2 must use the same local IP",
+        ));
+    }
+    if args.outer_addr1.ip() != args.outer_addr2.ip() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "outer-addr1 and outer-addr2 must use the same public IP",
+        ));
+    }
+    if args.bind_addr1.port() == args.bind_addr2.port() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "the primary and alternate STUN ports must differ",
+        ));
+    }
+    if args.outer_addr1.port() != args.bind_addr1.port()
+        || args.outer_addr2.port() != args.bind_addr2.port()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "each outer address port must match its bind address port",
+        ));
+    }
+    if args.change_addr1.port() != args.outer_addr2.port()
+        || args.change_addr2.port() != args.outer_addr1.port()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "change-addr1 must use the alternate port and change-addr2 the primary port",
+        ));
+    }
+    if args.change_addr1.ip() == args.outer_addr1.ip()
+        || args.change_addr2.ip() == args.outer_addr2.ip()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "each change address must use a different public IP",
+        ));
+    }
+    Ok(())
+}
 
-    let _ = tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_ansi(false)
-                .with_writer(file),
+fn init_logger() {
+    let _ = tracing_subscriber::fmt()
+        .with_target(true)
+        .with_ansi(false)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
         )
         .try_init();
-    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_args() -> Arguments {
+        Arguments {
+            bind_addr1: "10.0.0.1:20002".parse().unwrap(),
+            bind_addr2: "10.0.0.1:20003".parse().unwrap(),
+            change_addr1: "198.51.100.2:20003".parse().unwrap(),
+            change_addr2: "198.51.100.2:20002".parse().unwrap(),
+            outer_addr1: "198.51.100.1:20002".parse().unwrap(),
+            outer_addr2: "198.51.100.1:20003".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn production_pair_is_valid() {
+        validate_args(&valid_args()).unwrap();
+    }
+
+    #[test]
+    fn shared_change_address_cannot_preserve_both_port_relationships() {
+        let mut args = valid_args();
+        args.change_addr2 = args.change_addr1;
+        assert!(validate_args(&args).is_err());
+    }
+
+    #[test]
+    fn change_address_must_change_public_ip() {
+        let mut args = valid_args();
+        args.change_addr1 = "198.51.100.1:20003".parse().unwrap();
+        assert!(validate_args(&args).is_err());
+    }
 }

--- a/qtraversal/src/nat/client.rs
+++ b/qtraversal/src/nat/client.rs
@@ -689,7 +689,7 @@ struct StunClientState<I: RefIO + 'static> {
     task: Option<AbortOnDropHandle<()>>,
 }
 
-pub const DEFAULT_STUN_SERVER: &str = "nat.genmeta.net:20004";
+pub const DEFAULT_STUN_SERVER: &str = "nat.genmeta.net:20002";
 
 impl<I: RefIO + 'static> StunClientState<I> {
     pub fn new(

--- a/qtraversal/src/nat/server.rs
+++ b/qtraversal/src/nat/server.rs
@@ -22,17 +22,28 @@ use crate::nat::{
 
 #[derive(Debug, Clone, Default)]
 pub struct StunServerConfig {
+    /// Port of the other listener on the same public IP.
     change_port: Option<u16>,
+    /// Public listener on another IP used for CHANGE_IP requests and advertised
+    /// as CHANGED-ADDRESS.
     change_address: Option<SocketAddr>,
+    /// Public address of this listener, used as SOURCE-ADDRESS when the bind
+    /// address is private (for example, an EC2 instance behind an Elastic IP).
+    outer_address: Option<SocketAddr>,
 }
 
 #[bon::bon]
 impl StunServerConfig {
     #[builder(finish_fn = init)]
-    pub fn new(change_port: Option<u16>, change_address: Option<SocketAddr>) -> Self {
+    pub fn new(
+        change_port: Option<u16>,
+        change_address: Option<SocketAddr>,
+        outer_address: Option<SocketAddr>,
+    ) -> Self {
         Self {
             change_port,
             change_address,
+            outer_address,
         }
     }
 }
@@ -49,6 +60,7 @@ impl<I: RefIO + 'static> StunServer<I> {
         info!(
             target: "stun",
             local_addr = ?ref_iface.iface().local_addr(),
+            outer_address = ?config.outer_address,
             change_port = ?config.change_port,
             change_address = ?config.change_address,
             "new stun server",
@@ -75,6 +87,7 @@ async fn serve_loop<I: RefIO>(
 ) -> io::Result<()> {
     info!(target: "stun", "server started");
     let local_addr = ref_iface.iface().local_addr()?;
+    let source_addr = config.outer_address.unwrap_or(local_addr);
 
     while let Some((request, txid, src)) = stun_router.receive_request().await {
         trace!(target: "stun", ?request, "recv request");
@@ -98,14 +111,11 @@ async fn serve_loop<I: RefIO>(
                     .await?;
             }
             (None, Some(&response_addr)) => {
-                let mut attrs = vec![
-                    Attr::SourceAddress(local_addr),
-                    Attr::MappedAddress(response_addr),
-                ];
-                if let Some(addr) = config.change_address {
-                    attrs.push(Attr::ChangedAddress(addr));
-                }
-                let response = Response::with(attrs);
+                let response = Response::with(response_attributes(
+                    source_addr,
+                    response_addr,
+                    config.change_address,
+                ));
                 trace!(target: "stun", ?response, to = %response_addr, "send response");
                 ref_iface
                     .iface()
@@ -113,11 +123,8 @@ async fn serve_loop<I: RefIO>(
                     .await?;
             }
             _ => {
-                let mut attrs = vec![Attr::SourceAddress(local_addr), Attr::MappedAddress(src)];
-                if let Some(addr) = config.change_address {
-                    attrs.push(Attr::ChangedAddress(addr));
-                }
-                let response = Response::with(attrs);
+                let response =
+                    Response::with(response_attributes(source_addr, src, config.change_address));
                 trace!(target: "stun", ?response, to = %src, "send response");
                 ref_iface
                     .iface()
@@ -129,6 +136,21 @@ async fn serve_loop<I: RefIO>(
 
     trace!(target: "stun", "request handler finished with no more requests");
     Ok(())
+}
+
+fn response_attributes(
+    source_addr: SocketAddr,
+    mapped_addr: SocketAddr,
+    changed_addr: Option<SocketAddr>,
+) -> Vec<Attr> {
+    let mut attrs = vec![
+        Attr::SourceAddress(source_addr),
+        Attr::MappedAddress(mapped_addr),
+    ];
+    if let Some(addr) = changed_addr {
+        attrs.push(Attr::ChangedAddress(addr));
+    }
+    attrs
 }
 
 fn select_change_target(
@@ -233,5 +255,47 @@ impl Component for StunServerComponent {
                 StunServer::new(inner.ref_iface.clone(), router, inner.config.clone()).spawn(),
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_advertises_outer_instead_of_private_bind_address() {
+        let outer = "198.51.100.10:20002".parse().unwrap();
+        let mapped = "203.0.113.20:45000".parse().unwrap();
+        let changed = "198.51.100.11:20003".parse().unwrap();
+
+        assert_eq!(
+            response_attributes(outer, mapped, Some(changed)),
+            vec![
+                Attr::SourceAddress(outer),
+                Attr::MappedAddress(mapped),
+                Attr::ChangedAddress(changed),
+            ]
+        );
+    }
+
+    #[test]
+    fn change_targets_preserve_requested_address_and_port_relationship() {
+        let local = "10.0.0.10:20002".parse().unwrap();
+        let client = "203.0.113.20:45000".parse().unwrap();
+        let changed = "198.51.100.11:20003".parse().unwrap();
+        let config = StunServerConfig::builder()
+            .change_port(20003)
+            .change_address(changed)
+            .outer_address("198.51.100.10:20002".parse().unwrap())
+            .init();
+
+        assert_eq!(
+            select_change_target(client, CHANGE_PORT, local, &config).unwrap(),
+            "10.0.0.10:20003".parse().unwrap()
+        );
+        assert_eq!(
+            select_change_target(client, CHANGE_IP | CHANGE_PORT, local, &config).unwrap(),
+            changed
+        );
     }
 }

--- a/qtraversal/tools/run_stun.sh
+++ b/qtraversal/tools/run_stun.sh
@@ -1,5 +1,5 @@
 qtraversal/tools/build_nat.sh
 cargo build --example stun_server --release
-ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.64:20002 --bind-addr2 10.10.0.64:20003 --change-addr 10.10.0.66:20002 --outer-addr1 10.10.0.64:20002  --outer-addr2 10.10.0.64:20003 &
-ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.66:20002 --bind-addr2 10.10.0.66:20003 --change-addr 10.10.0.68:20002 --outer-addr1 10.10.0.66:20002  --outer-addr2 10.10.0.66:20003 &
-ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.68:20002 --bind-addr2 10.10.0.68:20003 --change-addr 10.10.0.64:20002 --outer-addr1 10.10.0.68:20002  --outer-addr2 10.10.0.68:20003 &
+ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.64:20002 --bind-addr2 10.10.0.64:20003 --change-addr1 10.10.0.66:20003 --change-addr2 10.10.0.66:20002 --outer-addr1 10.10.0.64:20002 --outer-addr2 10.10.0.64:20003 &
+ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.66:20002 --bind-addr2 10.10.0.66:20003 --change-addr1 10.10.0.68:20003 --change-addr2 10.10.0.68:20002 --outer-addr1 10.10.0.66:20002 --outer-addr2 10.10.0.66:20003 &
+ip netns exec nss nohup target/release/examples/stun_server --bind-addr1 10.10.0.68:20002 --bind-addr2 10.10.0.68:20003 --change-addr1 10.10.0.64:20003 --change-addr2 10.10.0.64:20002 --outer-addr1 10.10.0.68:20002 --outer-addr2 10.10.0.68:20003 &

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qudp"
-version = "0.7.0"
+version = "0.7.1-beta.1"
 edition.workspace = true
 description = "High-performance UDP encapsulation for QUIC"
 readme.workspace = true


### PR DESCRIPTION
## Summary

- bound ACK receive history without relying on peer ACK progress
- preserve path-local ACK triggers and sparse multipath ACK ranges
- fix STUN server address handling and align beta crate versions

## Release

- Planned tag: `v0.7.1-beta.1`
- Surface: 11 updated DQuic workspace crates on crates.io

## Verification

- `cargo test --workspace --all-features --all-targets -- --test-threads=1`
- locked publish dry-runs for all 11 release crates

## Release notes

Bound ACK journal memory independently of peer ACK state, keep ACK generation
path-local across sparse multipath packet numbers, and preserve configured
STUN server addresses. See `CHANGELOG.md` for the published crate versions.
