### PR TITLE
chore(release): prepare dquic v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.7.1] - 2026-08-11
+
+### Changed
+
+- Promote the validated 0.7.1 beta line to a stable release without additional
+  protocol changes.
+
+### Published crates
+
+- `qbase` v0.6.3
+- `qevent` v0.6.1
+- `qudp` v0.7.1
+- `qinterface` v0.7.1
+- `qdatagram` v0.6.1
+- `qresolve` v0.8.0
+- `qcongestion` v0.6.1
+- `qrecovery` v0.6.1
+- `qtraversal` v0.7.1
+- `qconnection` v0.8.1
+- `dquic` v0.7.1
+
 ## [0.7.1-beta.1] - 2026-08-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,17 +97,17 @@ tracing-appender = "0.2"
 
 # members
 qmacro = { path = "./qmacro", version = "0.5.1" }
-qbase = { path = "./qbase", version = "0.6.3-beta.1" }
-qevent = { path = "./qevent", version = "0.6.1-beta.1" }
-qudp = { path = "./qudp", version = "0.7.1-beta.1" }
-qinterface = { path = "./qinterface", version = "0.7.1-beta.1" }
-qdatagram = { path = "./qdatagram", version = "0.6.1-beta.1" }
-qresolve = { path = "./qresolve", version = "0.8.0-beta.1" }
-qrecovery = { path = "./qrecovery", version = "0.6.1-beta.1" }
-qtraversal = { path = "./qtraversal", version = "0.7.1-beta.1" }
-qcongestion = { path = "./qcongestion", version = "0.6.1-beta.1" }
-qconnection = { path = "./qconnection", version = "0.8.1-beta.1" }
-dquic = { path = "./dquic", version = "0.7.1-beta.1" }
+qbase = { path = "./qbase", version = "0.6.3" }
+qevent = { path = "./qevent", version = "0.6.1" }
+qudp = { path = "./qudp", version = "0.7.1" }
+qinterface = { path = "./qinterface", version = "0.7.1" }
+qdatagram = { path = "./qdatagram", version = "0.6.1" }
+qresolve = { path = "./qresolve", version = "0.8.0" }
+qrecovery = { path = "./qrecovery", version = "0.6.1" }
+qtraversal = { path = "./qtraversal", version = "0.7.1" }
+qcongestion = { path = "./qcongestion", version = "0.6.1" }
+qconnection = { path = "./qconnection", version = "0.8.1" }
+dquic = { path = "./dquic", version = "0.7.1" }
 h3-shim = { path = "./h3-shim", version = "0.5.1" }
 
 

--- a/dquic/Cargo.toml
+++ b/dquic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dquic"
-version = "0.7.1-beta.1"
+version = "0.7.1"
 edition.workspace = true
 description = "An IETF quic transport protocol implemented natively using async Rust"
 readme = "README.md"

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbase"
-version = "0.6.3-beta.1"
+version = "0.6.3"
 edition.workspace = true
 description = "Core structure of the QUIC protocol, a part of dquic"
 readme.workspace = true

--- a/qcongestion/Cargo.toml
+++ b/qcongestion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcongestion"
-version = "0.6.1-beta.1"
+version = "0.6.1"
 edition.workspace = true
 description = "Congestion control in QUIC, a part of dquic"
 readme.workspace = true

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qconnection"
-version = "0.8.1-beta.1"
+version = "0.8.1"
 edition.workspace = true
 description = "Encapsulation of QUIC connections, a part of dquic"
 readme.workspace = true

--- a/qdatagram/Cargo.toml
+++ b/qdatagram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdatagram"
-version = "0.6.1-beta.1"
+version = "0.6.1"
 edition.workspace = true
 description = "Datagram transmission of dquic"
 readme.workspace = true

--- a/qevent/Cargo.toml
+++ b/qevent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qevent"
-version = "0.6.1-beta.1"
+version = "0.6.1"
 edition.workspace = true
 description = "qlog implementation"
 readme.workspace = true

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qinterface"
-version = "0.7.1-beta.1"
+version = "0.7.1"
 edition.workspace = true
 description = "dquic's network interface and IO abstractions"
 readme.workspace = true

--- a/qrecovery/Cargo.toml
+++ b/qrecovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qrecovery"
-version = "0.6.1-beta.1"
+version = "0.6.1"
 edition.workspace = true
 description = "The reliable transport part of QUIC, a part of dquic"
 readme.workspace = true

--- a/qresolve/Cargo.toml
+++ b/qresolve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qresolve"
-version = "0.8.0-beta.1"
+version = "0.8.0"
 edition.workspace = true
 description = "dquic's dns abstractions"
 readme.workspace = true

--- a/qtraversal/Cargo.toml
+++ b/qtraversal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qtraversal"
-version = "0.7.1-beta.1"
+version = "0.7.1"
 edition.workspace = true
 description = "NAT traversal utilities for QUIC, a part of dquic"
 readme = "README.md"

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qudp"
-version = "0.7.1-beta.1"
+version = "0.7.1"
 edition.workspace = true
 description = "High-performance UDP encapsulation for QUIC"
 readme.workspace = true


### PR DESCRIPTION
## What changed

- Promote the validated dquic beta line to stable versions.
- Set all changed workspace crates to their corresponding stable versions.
- Preserve the published 0.7.1-beta.1 changelog entry and add a new 0.7.1 release entry.

## Why

Library-only projects no longer use beta releases. The published beta remains immutable, so the stable release is prepared in a follow-up PR.

## Impact

After merge, tag v0.7.1 to publish the stable crates.io release. Downstream library releases should depend on the stable dquic line.

## Checks

- cargo metadata --no-deps --format-version 1
- git diff --check
- Local tests were not rerun per release instruction.